### PR TITLE
Use npm for dependencies & scripts and update German data.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/temp_*
+/js/_bcv_parser.js

--- a/Readme.md
+++ b/Readme.md
@@ -582,11 +582,18 @@ The language's grammar file is wrapped into the relevant `*_bcv_parser.js` file.
 
 ### Build Instructions
 
+In preparation, run `npm install` once.
+
+#### Adding a new language
+
 1. In `src`, create a folder named after the [ISO 639 code](https://www.loc.gov/standards/iso639-2/php/code_list.php) of the desired language. For example: `fr`.
 2. Create a data.txt file inside that folder. Lines that start with `#` are comments. Lines that start with `$` are variables. Lines that start with an OSIS book name are a tab-separated series of regular expressions (a backtick following an accented character means not to allow the unaccented version of that character). Lines that start with `=` are the order in which to check the regular expressions (check for "3 John" before "John," for example). Lines that start with `*` are the preferred long and short names for each OSIS (not used here, but potentially used in a Bible application).
-3. In `bin`, run `01.add_lang.pl [ISO code]` to create the `src` files. This file expects `node` to be available in your `$PATH`.For example, `01.add_lang.pl fr`.
-4. In `bin`, run `02.compile.pl [ISO code]` to create the output Javascript files and tests. This file expects `pegjs` and `coffee` to be available in your `$PATH`. For example: `02.compile.pl fr`.
-5. In `bin`, run `03.run_tests.sh` to run tests on all the available languages in `test/js`. It requires [jasmine-node](https://github.com/mhevery/jasmine-node). Alternately, visit the relevant `test/[ISO code].html` file in a browser (which expects [Jasmine](https://github.com/pivotal/jasmine) to be in `lib/jasmine`).
+5. Run `npm run add-language [ISO code]` to create the `src` files for this new language.
+
+#### Compiling and testing a language
+
+4. Run `npm run build-language [ISO code]` to create the output Javascript files and tests.
+5. Run `npm run test-language [ISO code]` to run the tests for that particular language or `npm test` to run the tests for all languages. (Alternatively, visit the relevant `test/[ISO code].html` file in a browser, which expects [Jasmine](https://github.com/pivotal/jasmine) to be available in `lib/jasmine`.)
 
 ## Purpose
 

--- a/bin/01.add_lang.pl
+++ b/bin/01.add_lang.pl
@@ -602,7 +602,7 @@ sub make_tests
 			foreach my $expanded (expand_abbrev_vars($abbrev))
 			{
 				add_abbrev_to_all_abbrevs($osis, $expanded, \%all_abbrevs);
-				push @tests, "\t\texpect(p.parse(\"$expanded 1:1\").osis()).toEqual(\"$match\")";
+				push @tests, "\t\texpect(p.parse(\"$expanded 1:1\").osis()).toEqual(\"$match\", \"parsing: '$expanded 1:1'\")";
 			}
 			foreach my $alt_osis (@osises)
 			{
@@ -644,7 +644,7 @@ sub make_tests
 				foreach my $expanded (expand_abbrev_vars($abbrev))
 				{
 					$expanded = uc_normalize($expanded);
-					push @out, "\t\texpect(p.parse(\"$expanded 1:1\").osis()).toEqual(\"$match\")";
+					push @out, "\t\texpect(p.parse(\"$expanded 1:1\").osis()).toEqual(\"$match\", \"parsing: '$expanded 1:1'\")";
 				}
 			}
 		}
@@ -770,9 +770,9 @@ sub add_range_tests
 	{
 		foreach my $to (expand_abbrev(remove_exclamations(handle_accents($abbrev))))
 		{
-			push @out, "		expect(p.parse(\"Titus 1:1 $to 2\").osis()).toEqual \"Titus.1.1-Titus.1.2\"";
-			push @out, "		expect(p.parse(\"Matt 1${to}2\").osis()).toEqual \"Matt.1-Matt.2\"";
-			push @out, "		expect(p.parse(\"Phlm 2 " . uc_normalize($to) . " 3\").osis()).toEqual \"Phlm.1.2-Phlm.1.3\"";
+			push @out, "		expect(p.parse(\"Titus 1:1 $to 2\").osis()).toEqual(\"Titus.1.1-Titus.1.2\", \"parsing: 'Titus 1:1 $to 2'\")";
+			push @out, "		expect(p.parse(\"Matt 1${to}2\").osis()).toEqual(\"Matt.1-Matt.2\", \"parsing: 'Matt 1${to}2'\")";
+			push @out, "		expect(p.parse(\"Phlm 2 " . uc_normalize($to) . " 3\").osis()).toEqual(\"Phlm.1.2-Phlm.1.3\", \"parsing: 'Phlm 2 " . uc_normalize($to) . " 3'\")";
 		}
 	}
 	return @out;
@@ -786,8 +786,8 @@ sub add_chapter_tests
 	{
 		foreach my $chapter (expand_abbrev(remove_exclamations(handle_accents($abbrev))))
 		{
-			push @out, "		expect(p.parse(\"Titus 1:1, $chapter 2\").osis()).toEqual \"Titus.1.1,Titus.2\"";
-			push @out, "		expect(p.parse(\"Matt 3:4 " . uc_normalize($chapter) . " 6\").osis()).toEqual \"Matt.3.4,Matt.6\"";
+			push @out, "		expect(p.parse(\"Titus 1:1, $chapter 2\").osis()).toEqual(\"Titus.1.1,Titus.2\", \"parsing: 'Titus 1:1, $chapter 2'\")";
+			push @out, "		expect(p.parse(\"Matt 3:4 " . uc_normalize($chapter) . " 6\").osis()).toEqual(\"Matt.3.4,Matt.6\", \"parsing: 'Matt 3:4 " . uc_normalize($chapter) . " 6'\")";
 		}
 	}
 	return @out;
@@ -801,8 +801,8 @@ sub add_verse_tests
 	{
 		foreach my $verse (expand_abbrev(remove_exclamations(handle_accents($abbrev))))
 		{
-			push @out, "		expect(p.parse(\"Exod 1:1 $verse 3\").osis()).toEqual \"Exod.1.1,Exod.1.3\"";
-			push @out, "		expect(p.parse(\"Phlm " . uc_normalize($verse) . " 6\").osis()).toEqual \"Phlm.1.6\"";
+			push @out, "		expect(p.parse(\"Exod 1:1 $verse 3\").osis()).toEqual(\"Exod.1.1,Exod.1.3\", \"parsing: 'Exod 1:1 $verse 3'\")";
+			push @out, "		expect(p.parse(\"Phlm " . uc_normalize($verse) . " 6\").osis()).toEqual(\"Phlm.1.6\", \"parsing: 'Phlm " . uc_normalize($verse) . " 6'\")";
 		}
 	}
 	return @out;
@@ -816,8 +816,8 @@ sub add_sequence_tests
 	{
 		foreach my $and (expand_abbrev(remove_exclamations(handle_accents($abbrev))))
 		{
-			push @out, "		expect(p.parse(\"Exod 1:1 $and 3\").osis()).toEqual \"Exod.1.1,Exod.1.3\"";
-			push @out, "		expect(p.parse(\"Phlm 2 " . uc_normalize($and) . " 6\").osis()).toEqual \"Phlm.1.2,Phlm.1.6\"";
+			push @out, "		expect(p.parse(\"Exod 1:1 $and 3\").osis()).toEqual(\"Exod.1.1,Exod.1.3\", \"parsing: 'Exod 1:1 $and 3'\")";
+			push @out, "		expect(p.parse(\"Phlm 2 " . uc_normalize($and) . " 6\").osis()).toEqual(\"Phlm.1.2,Phlm.1.6\", \"parsing: 'Phlm 2 " . uc_normalize($and) . " 6'\")";
 		}
 	}
 	return @out;
@@ -831,8 +831,8 @@ sub add_title_tests
 	{
 		foreach my $title (expand_abbrev(remove_exclamations(handle_accents($abbrev))))
 		{
-			push @out, "		expect(p.parse(\"Ps 3 $title, 4:2, 5:$title\").osis()).toEqual \"Ps.3.1,Ps.4.2,Ps.5.1\"";
-			push @out, "		expect(p.parse(\"" . uc_normalize("Ps 3 $title, 4:2, 5:$title") . "\").osis()).toEqual \"Ps.3.1,Ps.4.2,Ps.5.1\"";
+			push @out, "		expect(p.parse(\"Ps 3 $title, 4:2, 5:$title\").osis()).toEqual(\"Ps.3.1,Ps.4.2,Ps.5.1\", \"parsing: 'Ps 3 $title, 4:2, 5:$title'\")";
+			push @out, "		expect(p.parse(\"" . uc_normalize("Ps 3 $title, 4:2, 5:$title") . "\").osis()).toEqual(\"Ps.3.1,Ps.4.2,Ps.5.1\", \"parsing: '" . uc_normalize("Ps 3 $title, 4:2, 5:$title") . "'\")";
 		}
 	}
 	return @out;
@@ -847,8 +847,8 @@ sub add_ff_tests
 	{
 		foreach my $ff (expand_abbrev(remove_exclamations(handle_accents($abbrev))))
 		{
-			push @out, "		expect(p.parse(\"Rev 3$ff, 4:2$ff\").osis()).toEqual \"Rev.3-Rev.22,Rev.4.2-Rev.4.11\"";
-			push @out, "		expect(p.parse(\"" . uc_normalize("Rev 3 $ff, 4:2 $ff") . "\").osis()).toEqual \"Rev.3-Rev.22,Rev.4.2-Rev.4.11\"" unless ($lang eq 'it');
+			push @out, "		expect(p.parse(\"Rev 3$ff, 4:2$ff\").osis()).toEqual(\"Rev.3-Rev.22,Rev.4.2-Rev.4.11\", \"parsing: 'Rev 3$ff, 4:2$ff'\")";
+			push @out, "		expect(p.parse(\"" . uc_normalize("Rev 3 $ff, 4:2 $ff") . "\").osis()).toEqual(\"Rev.3-Rev.22,Rev.4.2-Rev.4.11\", \"parsing: '" . uc_normalize("Rev 3 $ff, 4:2 $ff") . "'\")" unless ($lang eq 'it');
 		}
 	}
 	push @out, "\t\tp.set_options {case_sensitive: \"none\"}" if ($lang eq 'it');
@@ -865,14 +865,14 @@ sub add_next_tests
 	{
 		foreach my $next (expand_abbrev(remove_exclamations(handle_accents($abbrev))))
 		{
-			push @out, "		expect(p.parse(\"Rev 3:1$next, 4:2$next\").osis()).toEqual \"Rev.3.1-Rev.3.2,Rev.4.2-Rev.4.3\"";
-			push @out, "		expect(p.parse(\"" . uc_normalize("Rev 3 $next, 4:2 $next") . "\").osis()).toEqual \"Rev.3-Rev.4,Rev.4.2-Rev.4.3\"" unless ($lang eq 'it');
-			push @out, "		expect(p.parse(\"Jude 1$next, 2$next\").osis()).toEqual \"Jude.1.1-Jude.1.2,Jude.1.2-Jude.1.3\"";
-			push @out, "		expect(p.parse(\"Gen 1:31$next\").osis()).toEqual \"Gen.1.31-Gen.2.1\"";
-			push @out, "		expect(p.parse(\"Gen 1:2-31$next\").osis()).toEqual \"Gen.1.2-Gen.2.1\"";
-			push @out, "		expect(p.parse(\"Gen 1:2$next-30\").osis()).toEqual \"Gen.1.2-Gen.1.3,Gen.1.30\"";
-			push @out, "		expect(p.parse(\"Gen 50$next, Gen 50:26$next\").osis()).toEqual \"Gen.50,Gen.50.26\"";
-			push @out, "		expect(p.parse(\"Gen 1:32$next, Gen 51$next\").osis()).toEqual \"\"";
+			push @out, "		expect(p.parse(\"Rev 3:1$next, 4:2$next\").osis()).toEqual(\"Rev.3.1-Rev.3.2,Rev.4.2-Rev.4.3\", \"parsing: 'Rev 3:1$next, 4:2$next'\")";
+			push @out, "		expect(p.parse(\"" . uc_normalize("Rev 3 $next, 4:2 $next") . "\").osis()).toEqual(\"Rev.3-Rev.4,Rev.4.2-Rev.4.3\", \"parsing: '" . uc_normalize("Rev 3 $next, 4:2 $next") . "'\")" unless ($lang eq 'it');
+			push @out, "		expect(p.parse(\"Jude 1$next, 2$next\").osis()).toEqual(\"Jude.1.1-Jude.1.2,Jude.1.2-Jude.1.3\", \"parsing: 'Jude 1$next, 2$next'\")";
+			push @out, "		expect(p.parse(\"Gen 1:31$next\").osis()).toEqual(\"Gen.1.31-Gen.2.1\", \"parsing: 'Gen 1:31$next'\")";
+			push @out, "		expect(p.parse(\"Gen 1:2-31$next\").osis()).toEqual(\"Gen.1.2-Gen.2.1\", \"parsing: 'Gen 1:2-31$next'\")";
+			push @out, "		expect(p.parse(\"Gen 1:2$next-30\").osis()).toEqual(\"Gen.1.2-Gen.1.3,Gen.1.30\", \"parsing: 'Gen 1:2$next-30'\")";
+			push @out, "		expect(p.parse(\"Gen 50$next, Gen 50:26$next\").osis()).toEqual(\"Gen.50,Gen.50.26\", \"parsing: 'Gen 50$next, Gen 50:26$next'\")";
+			push @out, "		expect(p.parse(\"Gen 1:32$next, Gen 51$next\").osis()).toEqual(\"\", \"parsing: 'Gen 1:32$next, Gen 51$next'\")";
 		}
 	}
 	push @out, "\t\tp.set_options {case_sensitive: \"none\"}" if ($lang eq 'it');
@@ -927,7 +927,7 @@ sub add_book_range_tests
 			foreach my $to (expand_abbrev(remove_exclamations(handle_accents($to_regex))))
 			{
 				next if (exists $alreadys{"$first $to $third $abbrev"});
-				push @out, "		expect(p.parse(\"$first $to $third $abbrev\").osis()).toEqual \"1John.1-3John.1\"";
+				push @out, "		expect(p.parse(\"$first $to $third $abbrev\").osis()).toEqual(\"1John.1-3John.1\", \"parsing: '$first $to $third $abbrev'\")";
 				$alreadys{"$first $to $third $abbrev"} = 1;
 			}
 		}
@@ -940,8 +940,8 @@ sub add_boundary_tests
 	my @out;
 	push @out, "\tit \"should handle boundaries ($lang)\", ->";
 	push @out, "		p.set_options {book_alone_strategy: \"full\"}";
-	push @out, "		expect(p.parse(\"\\u2014Matt\\u2014\").osis()).toEqual \"Matt.1-Matt.28\"";
-	push @out, "		expect(p.parse(\"\\u201cMatt 1:1\\u201d\").osis()).toEqual \"Matt.1.1\"";
+	push @out, "		expect(p.parse(\"\\u2014Matt\\u2014\").osis()).toEqual(\"Matt.1-Matt.28\", \"parsing: '\\u2014Matt\\u2014'\")";
+	push @out, "		expect(p.parse(\"\\u201cMatt 1:1\\u201d\").osis()).toEqual(\"Matt.1.1\", \"parsing: '\\u201cMatt 1:1\\u201d'\")";
 	return @out;
 }
 
@@ -1085,7 +1085,7 @@ sub get_vars
 		$out{$key} = [@values];
 	}
 	close FILE;
-	
+
 	foreach my $char (@{$out{'$ALLOWED_CHARACTERS'}})
 	{
 		my $check = quotemeta $char;
@@ -1131,7 +1131,7 @@ sub get_pre_book_characters
 	foreach my $ref (@letters)
 	{
 		my ($start, $end) = @{$ref};
-		push @out, ($end eq $start) ? "$start" : 
+		push @out, ($end eq $start) ? "$start" :
 		"$start-$end";
 	}
 	my $out = join '', @out;

--- a/js/de_bcv_parser.js
+++ b/js/de_bcv_parser.js
@@ -2187,7 +2187,7 @@
     }
   };
 
-  bcv_parser.prototype.regexps.translations = /(?:(?:LUTH(?:1545|ER)|SCH(?:195|200)0|HFA|ELB))\b/gi;
+  bcv_parser.prototype.regexps.translations = /(?:(?:LUTH(?:1545|ER)|SCH(?:200|195)0|HFA|ELB))\b/gi;
 
   bcv_parser.prototype.translations = {
     aliases: {
@@ -2567,21 +2567,21 @@
 
   bcv_parser.prototype.regexps.space = "[\\s\\xa0]";
 
-  bcv_parser.prototype.regexps.escaped_passage = /(?:^|[^\x1f\x1e\dA-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:(?:ch(?:apters?|a?pts?\.?|a?p?s?\.?)?\s*\d+\s*(?:[\u2013\u2014\-]|through|thru|to)\s*\d+\s*(?:from|of|in)(?:\s+the\s+book\s+of)?\s*)|(?:ch(?:apters?|a?pts?\.?|a?p?s?\.?)?\s*\d+\s*(?:from|of|in)(?:\s+the\s+book\s+of)?\s*)|(?:\d+(?:th|nd|st)\s*ch(?:apter|a?pt\.?|a?p?\.?)?\s*(?:from|of|in)(?:\s+the\s+book\s+of)?\s*))?\x1f(\d+)(?:\/\d+)?\x1f(?:\/\d+\x1f|[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014]|Titel(?![a-z])|Kapitel|Verse|Vers|Kap|bis|und|vgl|Ver|ff|Vs|[a-e](?!\w)|$)+)/gi;
+  bcv_parser.prototype.regexps.escaped_passage = RegExp("(?:^|[^\\x1f\\x1e\\dA-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:(?:ch(?:apters?|a?pts?\\.?|a?p?s?\\.?)?\\s*\\d+\\s*(?:[\\u2013\\u2014\\-]|through|thru|to)\\s*\\d+\\s*(?:from|of|in)(?:\\s+the\\s+book\\s+of)?\\s*)|(?:ch(?:apters?|a?pts?\\.?|a?p?s?\\.?)?\\s*\\d+\\s*(?:from|of|in)(?:\\s+the\\s+book\\s+of)?\\s*)|(?:\\d+(?:th|nd|st)\\s*ch(?:apter|a?pt\\.?|a?p?\\.?)?\\s*(?:from|of|in)(?:\\s+the\\s+book\\s+of)?\\s*))?\\x1f(\\d+)(?:/\\d+)?\\x1f(?:/\\d+\\x1f|[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014]|Titel(?![a-z])|und" + bcv_parser.prototype.regexps.space + "+siehe" + bcv_parser.prototype.regexps.space + "+auch|sowie" + bcv_parser.prototype.regexps.space + "+auch|siehe" + bcv_parser.prototype.regexps.space + "+auch|und" + bcv_parser.prototype.regexps.space + "+siehe|und" + bcv_parser.prototype.regexps.space + "+auch|ff(?![a-z0-9äaöoüu])|Kapiteln|Kapiteln|Kapitel|Versen|Verses|siehe|sowie|Verse|Vers|Vers|Kap|bis|vgl|Vs|u|&|[a-e](?!\\w)|$)+)", "gi");
 
-  bcv_parser.prototype.regexps.match_end_split = /\d\W*Titel|\d\W*ff(?:[\s\xa0*]*\.)?|\d[\s\xa0*]*[a-e](?!\w)|\x1e(?:[\s\xa0*]*[)\]\uff09])?|[\d\x1f]/gi;
+  bcv_parser.prototype.regexps.match_end_split = /\d\W*Titel|\d\W*ff(?![a-z0-9äaöoüu])(?:[\s\xa0*]*\.)?|\d[\s\xa0*]*[a-e](?!\w)|\x1e(?:[\s\xa0*]*[)\]\uff09])?|[\d\x1f]/gi;
 
   bcv_parser.prototype.regexps.control = /[\x1e\x1f]/g;
 
   bcv_parser.prototype.regexps.pre_book = "[^A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ]";
 
-  bcv_parser.prototype.regexps.first = "(?:Erste|1)\\.?" + bcv_parser.prototype.regexps.space + "*";
+  bcv_parser.prototype.regexps.first = "(?:Erste[nrs]?|1)\\.?" + bcv_parser.prototype.regexps.space + "*";
 
-  bcv_parser.prototype.regexps.second = "(?:Zweite|2)\\.?" + bcv_parser.prototype.regexps.space + "*";
+  bcv_parser.prototype.regexps.second = "(?:Zweite[nrs]?|2)\\.?" + bcv_parser.prototype.regexps.space + "*";
 
-  bcv_parser.prototype.regexps.third = "(?:Dritte|3)\\.?" + bcv_parser.prototype.regexps.space + "*";
+  bcv_parser.prototype.regexps.third = "(?:Dritte[nrs]?|3)\\.?" + bcv_parser.prototype.regexps.space + "*";
 
-  bcv_parser.prototype.regexps.range_and = "(?:[&\u2013\u2014-]|(?:und|vgl)|bis)";
+  bcv_parser.prototype.regexps.range_and = "(?:[&\u2013\u2014-]|(?:und" + bcv_parser.prototype.regexps.space + "+siehe" + bcv_parser.prototype.regexps.space + "+auch|und" + bcv_parser.prototype.regexps.space + "+siehe|und" + bcv_parser.prototype.regexps.space + "+auch|sowie" + bcv_parser.prototype.regexps.space + "+auch|siehe" + bcv_parser.prototype.regexps.space + "+auch|siehe|sowie|u|&|vgl)|bis)";
 
   bcv_parser.prototype.regexps.range_only = "(?:[\u2013\u2014-]|bis)";
 
@@ -2595,24 +2595,24 @@
         regexp: /(\b)(Ps151)(?=\.1)/g
       }, {
         osis: ["Gen"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1\.?[\s\xa0]*Mose|Genesis)|(?:1\.?[\s\xa0]*Mos|Gen|1\.?[\s\xa0]*Mo|1\.?[\s\xa0]*Buch[\s\xa0]*Mose|Erste[\s\xa0]*(?:Buch[\s\xa0]*)?Mose))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Erste(?:[nrs][\s\xa0]*(?:Buch[\s\xa0]*)?|[\s\xa0]*(?:Buch[\s\xa0]*)?)Mose|1\.?[\s\xa0]*Buch[\s\xa0]*Mose|G(?:enesis|n)|1\.?[\s\xa0]*Mose|1(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|Gen))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Exod"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2\.?[\s\xa0]*Mose|Exodus)|(?:2\.?[\s\xa0]*Mos|Exod|2\.?[\s\xa0]*Mo|Ex|2\.?[\s\xa0]*Buch[\s\xa0]*Mose|Zweite[\s\xa0]*(?:Buch[\s\xa0]*)?Mose))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Zweite(?:[nrs][\s\xa0]*(?:Buch[\s\xa0]*)?|[\s\xa0]*(?:Buch[\s\xa0]*)?)Mose|2\.?[\s\xa0]*Buch[\s\xa0]*Mose|2\.?[\s\xa0]*Mose|2(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|Exodus|Ex(?:od)?))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Bel"],
         apocrypha: true,
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Bel(?:[\\s\\xa0]*und[\\s\\xa0]*Vom[\\s\\xa0]*Drachen)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Bel(?:[\\s\\xa0]*und[\\s\\xa0]*(?:Vom[\\s\\xa0]*Drachen|der?[\\s\\xa0]*Drache))?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Lev"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Levitikus|3\.?[\s\xa0]*Mose)|(?:3\.?[\s\xa0]*Mos|Lev|3\.?[\s\xa0]*Mo|3\.?[\s\xa0]*Buch[\s\xa0]*Mose|Dritte[\s\xa0]*(?:Buch[\s\xa0]*)?Mose))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Dritte(?:[nrs][\s\xa0]*(?:Buch[\s\xa0]*)?|[\s\xa0]*(?:Buch[\s\xa0]*)?)Mose|3\.?[\s\xa0]*Buch[\s\xa0]*Mose|L(?:evitikus|v)|3\.?[\s\xa0]*Mose|3(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|Lev))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Num"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:4\.?[\s\xa0]*Mose|Numeri)|(?:4\.?[\s\xa0]*Mos|Num|4\.?[\s\xa0]*Mo|4\.?[\s\xa0]*Buch[\s\xa0]*Mose|Vierte[\s\xa0]*(?:Buch[\s\xa0]*)?Mose))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Vierte(?:[ns][\s\xa0]*(?:Buch[\s\xa0]*)?|[\s\xa0]*(?:Buch[\s\xa0]*)?)Mose|4\.?[\s\xa0]*Buch[\s\xa0]*Mose|4\.?[\s\xa0]*Mose|4(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|N(?:umeri|m)|Num))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Sir"],
         apocrypha: true,
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Jesus[\\s\\xa0]*Sirach|Sir|Ecclesiasticus))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ecclesiasticus|Jesus[\\s\\xa0]*Sirach|Sir))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Wis"],
         apocrypha: true,
@@ -2630,58 +2630,58 @@
       }, {
         osis: ["PrMan"],
         apocrypha: true,
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Geb(?:et[\\s\\xa0]*(?:des[\\s\\xa0]*Manasse|Manasses?)|[\\s\\xa0]*Man)|(?:Or[\\s\\xa0]*|Pr)Man))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Das[\\s\\xa0]*Gebet[\\s\\xa0]*(?:des[\\s\\xa0]*Manasse|Manasses)|Gebet[\\s\\xa0]*des[\\s\\xa0]*Manasse|Geb(?:et[\\s\\xa0]*Manasses|[\\s\\xa0]*Man)|Gebet[\\s\\xa0]*Manasse|(?:Or[\\s\\xa0]*|Pr)Man))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Deut"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:D(?:euteronomium|tn)|5\.?[\s\xa0]*Mose|5(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|Deut|5\.?[\s\xa0]*Buch[\s\xa0]*Mose|F[u\xFC]nfte[\s\xa0]*(?:Buch[\s\xa0]*)?Mose))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:F[u\xFC]nftes[\s\xa0]*(?:Buch[\s\xa0]*)?Mose|D(?:euteronomium|tn)|5\.?[\s\xa0]*Buch[\s\xa0]*Mose|5\.?[\s\xa0]*Mose|5(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|D(?:eu)?t))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Josh"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Jos(?:ua|h)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Judg"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ri(?:chter)?|Judg))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ri(?:ch(?:ter)?)?|Judg))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Ruth"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ruth?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ru(?:th?)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["1Esd"],
         apocrypha: true,
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1(?:[\s\xa0]*Esra|Esd|\.[\s\xa0]*Esra|\.[\s\xa0]*Esr?|[\s\xa0]*Esr?)|Erste[\s\xa0]*Esra))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1Esd)|(?:Erste(?:[nrs][\s\xa0]*Esd?|[\s\xa0]*Esd?)ra|1(?:(?:\.[\s\xa0]*Esd?|[\s\xa0]*Esd?)ra|\.[\s\xa0]*Es(?:dr|r)?|[\s\xa0]*Es(?:dr|r)?)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["2Esd"],
         apocrypha: true,
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2(?:[\s\xa0]*Esra|Esd|\.[\s\xa0]*Esra|\.[\s\xa0]*Esr?|[\s\xa0]*Esr?)|Zweite[\s\xa0]*Esra))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2Esd)|(?:Zweite(?:[nrs][\s\xa0]*Esd?|[\s\xa0]*Esd?)ra|2(?:(?:\.[\s\xa0]*Esd?|[\s\xa0]*Esd?)ra|\.[\s\xa0]*Es(?:dr|r)?|[\s\xa0]*Es(?:dr|r)?)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Isa"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Isa(?:ias)?|Jes(?:aja)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Jes(?:aja)?|Isa(?:ias)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["2Sam"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2\.?[\s\xa0]*Samuel)|(?:2(?:\.[\s\xa0]*|[\s\xa0]*)?Sam|Zweite[\s\xa0]*Samuel))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Zweite[nrs]?[\s\xa0]*Samuel|2(?:\.?[\s\xa0]*Samuel|\.[\s\xa0]*Sam?|[\s\xa0]*Sam?|Sam)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["1Sam"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1\.?[\s\xa0]*Samuel)|(?:1(?:\.[\s\xa0]*|[\s\xa0]*)?Sam|Erste[\s\xa0]*Samuel))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Erste[nrs]?[\s\xa0]*Samuel|1(?:\.?[\s\xa0]*Samuel|\.[\s\xa0]*Sam?|[\s\xa0]*Sam?|Sam)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["2Kgs"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2(?:\.[\s\xa0]*K[o\xF6]|[\s\xa0]*K[o\xF6])nige)|(?:2(?:[\s\xa0]*K[o\xF6]n|Kgs|\.[\s\xa0]*K[o\xF6]n|\.?[\s\xa0]*Koenige)|Zweite[\s\xa0]*K(?:\xF6|oe?)nige))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Zweite(?:[nrs][\s\xa0]*K(?:oe?|\xF6)|[\s\xa0]*K(?:oe?|\xF6))nige|2(?:(?:\.[\s\xa0]*K(?:oe?|\xF6)|[\s\xa0]*K(?:oe?|\xF6))nige|\.[\s\xa0]*K(?:o(?:en?|n)?|\xF6n?)|[\s\xa0]*K(?:o(?:en?|n)?|\xF6n?)|\.[\s\xa0]*Kng|[\s\xa0]*Kng|Kgs)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["1Kgs"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1(?:\.[\s\xa0]*K[o\xF6]|[\s\xa0]*K[o\xF6])nige)|(?:1(?:[\s\xa0]*K[o\xF6]n|Kgs|\.[\s\xa0]*K[o\xF6]n|\.?[\s\xa0]*Koenige)|Erste[\s\xa0]*K(?:\xF6|oe?)nige))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Erste(?:[nrs][\s\xa0]*K(?:oe?|\xF6)|[\s\xa0]*K(?:oe?|\xF6))nige|1(?:(?:\.[\s\xa0]*K(?:oe?|\xF6)|[\s\xa0]*K(?:oe?|\xF6))nige|\.[\s\xa0]*K(?:o(?:en?|n)?|\xF6n?)|[\s\xa0]*K(?:o(?:en?|n)?|\xF6n?)|\.[\s\xa0]*Kng|[\s\xa0]*Kng|Kgs)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["2Chr"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2\.?[\s\xa0]*Chronik)|(?:Zweite[\s\xa0]*Chronik|2(?:\.[\s\xa0]*|[\s\xa0]*)?Chr))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Zweite[nrs]?[\s\xa0]*Chronik|2(?:\.?[\s\xa0]*Chronik|\.[\s\xa0]*Chr(?:on)?|[\s\xa0]*Chr(?:on)?|Chr)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["1Chr"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1\.?[\s\xa0]*Chronik)|(?:1(?:\.[\s\xa0]*|[\s\xa0]*)?Chr|Erste[\s\xa0]*Chronik))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Erste[nrs]?[\s\xa0]*Chronik|1(?:\.?[\s\xa0]*Chronik|\.[\s\xa0]*Chr(?:on)?|[\s\xa0]*Chr(?:on)?|Chr)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Ezra"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:E(?:sra?|zra)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:E(?:zra|sra?)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Neh"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Neh(?:emia)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["GkEsth"],
         apocrypha: true,
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ester[\\s\\xa0]*\\(Griechisch\\)|G(?:kEsth|r[\\s\\xa0]*Est)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ester[\\s\\xa0]*\\(Griechisch\\)|G(?:r[\\s\\xa0]*Est|kEsth)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Esth"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Est(?:h(?:er)?|er)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
@@ -2690,36 +2690,36 @@
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:(?:Ij|J)ob|Hi(?:ob)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Ps"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ps(?:alm(?:en)?)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ps(?:alm(?:en)?|lm)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["PrAzar"],
         apocrypha: true,
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Geb(?:et[\\s\\xa0]*des[\\s\\xa0]*Asarja|[\\s\\xa0]*As)|PrAzar))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Das[\\s\\xa0]*Gebet[\\s\\xa0]*(?:des[\\s\\xa0]*Asarja|Asarjas)|Gebet[\\s\\xa0]*(?:des[\\s\\xa0]*Asarja|Asarjas)|PrAzar|Geb[\\s\\xa0]*As))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Prov"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Spr(?:(?:\\xFC|ue?)che|ichw[o\\xF6]rter)?|Prov))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Spr(?:ichw(?:oe?|\\xF6)rter|(?:ue?|\\xFC)che)?|Prov))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Eccl"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:E(?:ccl(?:esiastes)?|kklesiastes)|Prediger|Kohelet|Pred|Koh))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:E(?:kklesiastes|ccl(?:esiastes)?)|Prediger|Kohelet|Pred|Koh))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["SgThree"],
         apocrypha: true,
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Der[\s\xa0]*Gesang[\s\xa0]*der[\s\xa0]*Drei[\s\xa0]*M[a\xE4]nner[\s\xa0]*im[\s\xa0]*feurigen[\s\xa0]*Ofen|Gesang[\s\xa0]*der[\s\xa0]*Drei|SgThree|Der[\s\xa0]*Gesang[\s\xa0]*der[\s\xa0]*Drei|L(?:obgesang[\s\xa0]*der[\s\xa0]*(?:drei[\s\xa0]*jungen[\s\xa0]*M[a\xE4]nner(?:[\s\xa0]*im[\s\xa0]*Feuerofen)?|3[\s\xa0]*jungen[\s\xa0]*M[a\xE4]nner)|3J)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Gesang[\s\xa0]*der[\s\xa0]*(?:drei(?:[\s\xa0]*(?:M(?:a(?:enner(?:[\s\xa0]*im[\s\xa0]*Feuerofen)?|nner(?:[\s\xa0]*im[\s\xa0]*Feuerofen)?)|\xE4nner(?:[\s\xa0]*im[\s\xa0]*Feuerofen)?)|im[\s\xa0]*Feuerofen))?|Drei)|SgThree|L3J))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Song"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:H(?:ohe(?:s(?:lied[\\s\\xa0]*Salomos|(?:[\\s\\xa0]*L|l)ied)|lied(?:[\\s\\xa0]*Salomonis)?)|ld)|Song))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:H(?:ohe(?:s(?:lied(?:[\\s\\xa0]*Salomo(?:ni)?s)?|[\\s\\xa0]*Lied)|lied(?:[\\s\\xa0]*Salomo(?:ni)?s)?)|ld)|Song))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Jer"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Jer(?:emias?)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Ezek"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ez(?:e(?:chiel|k))?|Hes(?:ekiel)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Hes(?:ekiel|ek)?|Ez(?:e(?:chiel|k))?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Dan"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Dan(?:iel)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Hos"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Hos(?:ea)?|Osee))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Hos(?:ea)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Joel"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Joel))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
@@ -2728,13 +2728,13 @@
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Am(?:os)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Obad"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ob(?:adja|d|ad)|Abdias))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ob(?:adja|ad|d)|Abdias))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Jonah"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Jona[hs]?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Mic"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Mi(?:c(?:h(?:a(?:as)?|\\xE4as))?)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Mi(?:c(?:h(?:a(?:eas|as)?|\\xE4as)?)?)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Nah"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Nah(?:um)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
@@ -2743,10 +2743,10 @@
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Hab(?:akuk)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Zeph"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ze(?:(?:ph|f)anja|ph|f)|Soph(?:onias)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ze(?:ph(?:anja)?|f(?:anja)?)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Hag"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ag(?:g(?:[a\\xE4]us)?)?|Hag(?:gai)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Hag(?:g(?:ai)?)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Zech"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Z(?:acharias|ech)|Sach(?:arja)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
@@ -2755,37 +2755,37 @@
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Mal(?:achias|eachi)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Matt"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:M(?:att(?:h[a\\xE4]us)?|t)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Das[\\s\\xa0]*Evangelium[\\s\\xa0]*nach[\\s\\xa0]*Matth(?:ae?|\\xE4)us|[\\s\\xa0]*Evangelium[\\s\\xa0]*nach[\\s\\xa0]*Matth(?:ae?|\\xE4)us|M(?:atth(?:ae?|\\xE4)usevangelium|att(?:h(?:ae?|\\xE4)us)?|t)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Mark"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:M(?:ark(?:us)?|k)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Das[\\s\\xa0]*Evangelium[\\s\\xa0]*nach[\\s\\xa0]*Markus|[\\s\\xa0]*Evangelium[\\s\\xa0]*nach[\\s\\xa0]*Markus|M(?:arkusevangelium|ark(?:us)?|k)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Luke"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:L(?:uk(?:as|e)|k)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Das[\\s\\xa0]*Evangelium[\\s\\xa0]*nach[\\s\\xa0]*Lukas|[\\s\\xa0]*Evangelium[\\s\\xa0]*nach[\\s\\xa0]*Lukas|L(?:uk(?:asevangelium|e)|uk(?:as)?|k)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["1John"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1John)|(?:1(?:\.?[\s\xa0]*Johannes|\.?[\s\xa0]*Joh)|Erste[\s\xa0]*Johannes))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1John)|(?:Erste[nrs]?[\s\xa0]*Johannes|1(?:\.?[\s\xa0]*Johannes|\.[\s\xa0]*Joh?|[\s\xa0]*Joh?)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["2John"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2John)|(?:2(?:\.?[\s\xa0]*Johannes|\.?[\s\xa0]*Joh)|Zweite[\s\xa0]*Johannes))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2John)|(?:Zweite[nrs]?[\s\xa0]*Johannes|2(?:\.?[\s\xa0]*Johannes|\.[\s\xa0]*Joh?|[\s\xa0]*Joh?)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["3John"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:3John)|(?:3(?:\.?[\s\xa0]*Johannes|\.?[\s\xa0]*Joh)|Dritte[\s\xa0]*Johannes))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:3John)|(?:Dritte[nrs]?[\s\xa0]*Johannes|3(?:\.?[\s\xa0]*Johannes|\.[\s\xa0]*Joh?|[\s\xa0]*Joh?)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["John"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Joh(?:annes|n)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Das[\\s\\xa0]*Evangelium[\\s\\xa0]*nach[\\s\\xa0]*Johannes|[\\s\\xa0]*Evangelium[\\s\\xa0]*nach[\\s\\xa0]*Johannes|Joh(?:annesevangelium|annes|n)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Acts"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:A(?:p(?:ostelgeschichte|g)|cts)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Rom"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:R(?:o(?:m(?:er)?|emer)|\\xF6m(?:er)?)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:R(?:o(?:em(?:er)?|m(?:er)?)|\\xF6m(?:er)?|m)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["2Cor"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2\.?[\s\xa0]*Korinther)|(?:(?:Zweite[\s\xa0]*Korinthe|2(?:[\s\xa0]*K|C|\.[\s\xa0]*K)o)r))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:(?:Zweite[nrs]?[\s\xa0]*Korinthe|2(?:\.?[\s\xa0]*Korinthe|(?:\.?[\s\xa0]*K|C)o))r))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["1Cor"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1\.?[\s\xa0]*Korinther)|(?:(?:1(?:[\s\xa0]*K|C|\.[\s\xa0]*K)o|Erste[\s\xa0]*Korinthe)r))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:(?:Erste[nrs]?[\s\xa0]*Korinthe|1(?:\.?[\s\xa0]*Korinthe|(?:\.?[\s\xa0]*K|C)o))r))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Gal"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Gal(?:ater)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
@@ -2800,16 +2800,16 @@
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Kol(?:osser)?|Col))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["2Thess"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2(?:\.?[\s\xa0]*Thessalonicher|(?:\.?[\s\xa0]*)?Thess)|Zweite[\s\xa0]*Thessalonicher))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Zweite[nrs]?[\s\xa0]*Thessalonicher|2(?:\.?[\s\xa0]*Thessalonicher|\.[\s\xa0]*Th(?:ess)?|[\s\xa0]*Th(?:ess)?|Thess)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["1Thess"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1(?:\.?[\s\xa0]*Thessalonicher|(?:\.?[\s\xa0]*)?Thess)|Erste[\s\xa0]*Thessalonicher))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Erste[nrs]?[\s\xa0]*Thessalonicher|1(?:\.?[\s\xa0]*Thessalonicher|\.[\s\xa0]*Th(?:ess)?|[\s\xa0]*Th(?:ess)?|Thess)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["2Tim"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2(?:\.?[\s\xa0]*Timotheus|(?:\.?[\s\xa0]*)?Tim)|Zweite[\s\xa0]*Timotheus))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Zweite[nrs]?[\s\xa0]*Timotheus|2(?:\.?[\s\xa0]*Timotheus|(?:\.?[\s\xa0]*)?Tim)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["1Tim"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1(?:\.?[\s\xa0]*Timotheus|(?:\.?[\s\xa0]*)?Tim)|Erste[\s\xa0]*Timotheus))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Erste[nrs]?[\s\xa0]*Timotheus|1(?:\.?[\s\xa0]*Timotheus|(?:\.?[\s\xa0]*)?Tim)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Titus"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Tit(?:us)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
@@ -2818,16 +2818,16 @@
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ph(?:ilemon|l?m)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Heb"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Heb(?:r(?:\\xE4er|aee?r)?)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:H(?:eb(?:r(?:aee?r|\\xE4er)?)?|b)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["Jas"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ja(?:k(?:obus(?:brief)?)?|s)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:J(?:a(?:k(?:obus(?:brief)?)?|s)|k)))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["2Pet"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2\.?[\s\xa0]*Petrus)|(?:2(?:[\s\xa0]*Petr|Pet|\.[\s\xa0]*Petr)|Zweite[\s\xa0]*Petrus))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Zweite[nrs]?[\s\xa0]*Petrus|2(?:\.?[\s\xa0]*Petrus|\.[\s\xa0]*Petr?|[\s\xa0]*Petr?|(?:\.[\s\xa0]*P|Pe|[\s\xa0]*P)t)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["1Pet"],
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1\.?[\s\xa0]*Petrus)|(?:1(?:[\s\xa0]*Petr|Pet|\.[\s\xa0]*Petr)|Erste[\s\xa0]*Petrus))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Erste[nrs]?[\s\xa0]*Petrus|1(?:\.?[\s\xa0]*Petrus|\.[\s\xa0]*Petr?|[\s\xa0]*Petr?|(?:\.[\s\xa0]*P|Pe|[\s\xa0]*P)t)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["Jude"],
         regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Jud(?:as|e)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
@@ -2846,29 +2846,23 @@
       }, {
         osis: ["Sus"],
         apocrypha: true,
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Sus(?:anna(?:[\\s\\xa0]*(?:und[\\s\\xa0]*die[\\s\\xa0]*Alten|im[\\s\\xa0]*Bade))?)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Sus(?:anna)?))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
       }, {
         osis: ["2Macc"],
         apocrypha: true,
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:2(?:\.?[\s\xa0]*Makkab[a\xE4]er|\.?[\s\xa0]*Makk|Macc)|Zweite[\s\xa0]*Makkab[a\xE4]er))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Zweite(?:[nrs][\s\xa0]*Makkab(?:aee?|\xE4e)|[\s\xa0]*Makkab(?:aee?|\xE4e))r|2(?:\.?[\s\xa0]*Makkab(?:aee?|\xE4e)r|\.?[\s\xa0]*Makk|Macc)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["3Macc"],
         apocrypha: true,
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:3(?:\.?[\s\xa0]*Makkab[a\xE4]er|\.?[\s\xa0]*Makk|Macc)|Dritte[\s\xa0]*Makkab[a\xE4]er))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Dritte(?:[nrs][\s\xa0]*Makkab(?:aee?|\xE4e)|[\s\xa0]*Makkab(?:aee?|\xE4e))r|3(?:\.?[\s\xa0]*Makkab(?:aee?|\xE4e)r|\.?[\s\xa0]*Makk|Macc)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["4Macc"],
         apocrypha: true,
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:4(?:\.?[\s\xa0]*Makkab[a\xE4]er|\.?[\s\xa0]*Makk|Macc)|Vierte[\s\xa0]*Makkab[a\xE4]er))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Vierte(?:[ns][\s\xa0]*Makkab(?:aee?|\xE4e)|[\s\xa0]*Makkab(?:aee?|\xE4e))r|4(?:\.?[\s\xa0]*Makkab(?:aee?|\xE4e)r|\.?[\s\xa0]*Makk|Macc)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }, {
         osis: ["1Macc"],
         apocrypha: true,
-        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:1(?:\.?[\s\xa0]*Makkab[a\xE4]er|\.?[\s\xa0]*Makk|Macc)|Erste[\s\xa0]*Makkab[a\xE4]er))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
-      }, {
-        osis: ["Ezra", "Esth"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Es))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
-      }, {
-        osis: ["Phil", "Phlm"],
-        regexp: RegExp("(^|" + bcv_parser.prototype.regexps.pre_book + ")((?:Ph))(?:(?=[\\d\\s\\xa0.:,;\\x1e\\x1f&\\(\\)\\uff08\\uff09\\[\\]/\"'\\*=~\\-\\u2013\\u2014])|$)", "gi")
+        regexp: /(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])((?:Erste(?:[nrs][\s\xa0]*Makkab(?:aee?|\xE4e)|[\s\xa0]*Makkab(?:aee?|\xE4e))r|1(?:\.?[\s\xa0]*Makkab(?:aee?|\xE4e)r|\.?[\s\xa0]*Makk|Macc)))(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]\/"'\*=~\-\u2013\u2014])|$)/gi
       }
     ];
     if (include_apocrypha === true && case_sensitive === "none") {
@@ -3076,85 +3070,101 @@ var grammar;
         peg$c39 = function(val) { return {"type": "c", "value": [val], "indices": [peg$savedPos, peg$currPos - 1]} },
         peg$c40 = "ff",
         peg$c41 = peg$literalExpectation("ff", false),
-        peg$c42 = /^[a-z]/,
-        peg$c43 = peg$classExpectation([["a", "z"]], false, false),
-        peg$c44 = function(val_1) { return {"type": "ff", "value": [val_1], "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c45 = function(val_1, val_2) { return {"type": "integer_title", "value": [val_1, val_2], "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c46 = "/9\x1F",
-        peg$c47 = peg$literalExpectation("/9\x1F", false),
-        peg$c48 = function(val) { return {"type": "context", "value": val.value, "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c49 = "/2\x1F",
-        peg$c50 = peg$literalExpectation("/2\x1F", false),
-        peg$c51 = ".1",
-        peg$c52 = peg$literalExpectation(".1", false),
-        peg$c53 = /^[0-9]/,
-        peg$c54 = peg$classExpectation([["0", "9"]], false, false),
-        peg$c55 = function(val) { return {"type": "bc", "value": [val, {"type": "c", "value": [{"type": "integer", "value": 151, "indices": [peg$currPos - 2, peg$currPos - 1]}], "indices": [peg$currPos - 2, peg$currPos - 1]}], "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c56 = function(val_1, val_2) { return {"type": "bcv", "value": [val_1, {"type": "v", "value": [val_2], "indices": [val_2.indices[0], val_2.indices[1]]}], "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c57 = /^[a-e]/,
-        peg$c58 = peg$classExpectation([["a", "e"]], false, false),
-        peg$c59 = function(val) { return {"type": "v", "value": [val], "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c60 = "kap",
-        peg$c61 = peg$literalExpectation("kap", false),
-        peg$c62 = "itel",
-        peg$c63 = peg$literalExpectation("itel", false),
-        peg$c64 = function() { return {"type": "c_explicit"} },
-        peg$c65 = "v",
-        peg$c66 = peg$literalExpectation("v", false),
-        peg$c67 = "erse",
-        peg$c68 = peg$literalExpectation("erse", false),
-        peg$c69 = "ers",
-        peg$c70 = peg$literalExpectation("ers", false),
-        peg$c71 = "er",
-        peg$c72 = peg$literalExpectation("er", false),
-        peg$c73 = "s",
-        peg$c74 = peg$literalExpectation("s", false),
-        peg$c75 = function() { return {"type": "v_explicit"} },
-        peg$c76 = ":",
-        peg$c77 = peg$literalExpectation(":", false),
-        peg$c78 = /^["']/,
-        peg$c79 = peg$classExpectation(["\"", "'"], false, false),
-        peg$c80 = /^[,;\/:&\-\u2013\u2014~]/,
-        peg$c81 = peg$classExpectation([",", ";", "/", ":", "&", "-", "\u2013", "\u2014", "~"], false, false),
-        peg$c82 = "und",
-        peg$c83 = peg$literalExpectation("und", false),
-        peg$c84 = "vgl",
-        peg$c85 = peg$literalExpectation("vgl", false),
-        peg$c86 = function() { return "" },
-        peg$c87 = /^[\-\u2013\u2014]/,
-        peg$c88 = peg$classExpectation(["-", "\u2013", "\u2014"], false, false),
-        peg$c89 = "bis",
-        peg$c90 = peg$literalExpectation("bis", false),
-        peg$c91 = "titel",
-        peg$c92 = peg$literalExpectation("titel", false),
-        peg$c93 = function(val) { return {type:"title", value: [val], "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c94 = "from",
-        peg$c95 = peg$literalExpectation("from", false),
-        peg$c96 = "of",
-        peg$c97 = peg$literalExpectation("of", false),
-        peg$c98 = "in",
-        peg$c99 = peg$literalExpectation("in", false),
-        peg$c100 = "the",
-        peg$c101 = peg$literalExpectation("the", false),
-        peg$c102 = "book",
-        peg$c103 = peg$literalExpectation("book", false),
-        peg$c104 = /^[([]/,
-        peg$c105 = peg$classExpectation(["(", "["], false, false),
-        peg$c106 = /^[)\]]/,
-        peg$c107 = peg$classExpectation([")", "]"], false, false),
-        peg$c108 = function(val) { return {"type": "translation_sequence", "value": val, "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c109 = "\x1E",
-        peg$c110 = peg$literalExpectation("\x1E", false),
-        peg$c111 = function(val) { return {"type": "translation", "value": val.value, "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c112 = ",000",
-        peg$c113 = peg$literalExpectation(",000", false),
-        peg$c114 = function(val) { return {"type": "integer", "value": parseInt(val.join(""), 10), "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c115 = /^[^\x1F\x1E([]/,
-        peg$c116 = peg$classExpectation(["\x1F", "\x1E", "(", "["], true, false),
-        peg$c117 = function(val) { return {"type": "word", "value": val.join(""), "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c118 = function(val) { return {"type": "stop", "value": val, "indices": [peg$savedPos, peg$currPos - 1]} },
-        peg$c119 = /^[\s\xa0*]/,
-        peg$c120 = peg$classExpectation([" ", "\t", "\r", "\n", "\xA0", "*"], false, false),
+        peg$c42 = /^[a-z0-9\xE4a\xF6o\xFCu]/i,
+        peg$c43 = peg$classExpectation([["a", "z"], ["0", "9"], "\xE4", "a", "\xF6", "o", "\xFC", "u"], false, true),
+        peg$c44 = /^[a-z]/,
+        peg$c45 = peg$classExpectation([["a", "z"]], false, false),
+        peg$c46 = function(val_1) { return {"type": "ff", "value": [val_1], "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c47 = function(val_1, val_2) { return {"type": "integer_title", "value": [val_1, val_2], "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c48 = "/9\x1F",
+        peg$c49 = peg$literalExpectation("/9\x1F", false),
+        peg$c50 = function(val) { return {"type": "context", "value": val.value, "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c51 = "/2\x1F",
+        peg$c52 = peg$literalExpectation("/2\x1F", false),
+        peg$c53 = ".1",
+        peg$c54 = peg$literalExpectation(".1", false),
+        peg$c55 = /^[0-9]/,
+        peg$c56 = peg$classExpectation([["0", "9"]], false, false),
+        peg$c57 = function(val) { return {"type": "bc", "value": [val, {"type": "c", "value": [{"type": "integer", "value": 151, "indices": [peg$currPos - 2, peg$currPos - 1]}], "indices": [peg$currPos - 2, peg$currPos - 1]}], "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c58 = function(val_1, val_2) { return {"type": "bcv", "value": [val_1, {"type": "v", "value": [val_2], "indices": [val_2.indices[0], val_2.indices[1]]}], "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c59 = /^[a-e]/,
+        peg$c60 = peg$classExpectation([["a", "e"]], false, false),
+        peg$c61 = function(val) { return {"type": "v", "value": [val], "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c62 = "kap",
+        peg$c63 = peg$literalExpectation("kap", false),
+        peg$c64 = "iteln",
+        peg$c65 = peg$literalExpectation("iteln", false),
+        peg$c66 = "itel",
+        peg$c67 = peg$literalExpectation("itel", false),
+        peg$c68 = function() { return {"type": "c_explicit"} },
+        peg$c69 = "v",
+        peg$c70 = peg$literalExpectation("v", false),
+        peg$c71 = "ersen",
+        peg$c72 = peg$literalExpectation("ersen", false),
+        peg$c73 = "erses",
+        peg$c74 = peg$literalExpectation("erses", false),
+        peg$c75 = "erse",
+        peg$c76 = peg$literalExpectation("erse", false),
+        peg$c77 = "ers",
+        peg$c78 = peg$literalExpectation("ers", false),
+        peg$c79 = "s",
+        peg$c80 = peg$literalExpectation("s", false),
+        peg$c81 = function() { return {"type": "v_explicit"} },
+        peg$c82 = ":",
+        peg$c83 = peg$literalExpectation(":", false),
+        peg$c84 = /^["']/,
+        peg$c85 = peg$classExpectation(["\"", "'"], false, false),
+        peg$c86 = /^[,;\/:&\-\u2013\u2014~]/,
+        peg$c87 = peg$classExpectation([",", ";", "/", ":", "&", "-", "\u2013", "\u2014", "~"], false, false),
+        peg$c88 = "und",
+        peg$c89 = peg$literalExpectation("und", false),
+        peg$c90 = "siehe",
+        peg$c91 = peg$literalExpectation("siehe", false),
+        peg$c92 = "auch",
+        peg$c93 = peg$literalExpectation("auch", false),
+        peg$c94 = "sowie",
+        peg$c95 = peg$literalExpectation("sowie", false),
+        peg$c96 = "u",
+        peg$c97 = peg$literalExpectation("u", false),
+        peg$c98 = "&",
+        peg$c99 = peg$literalExpectation("&", false),
+        peg$c100 = "vgl",
+        peg$c101 = peg$literalExpectation("vgl", false),
+        peg$c102 = function() { return "" },
+        peg$c103 = /^[\-\u2013\u2014]/,
+        peg$c104 = peg$classExpectation(["-", "\u2013", "\u2014"], false, false),
+        peg$c105 = "bis",
+        peg$c106 = peg$literalExpectation("bis", false),
+        peg$c107 = "titel",
+        peg$c108 = peg$literalExpectation("titel", false),
+        peg$c109 = function(val) { return {type:"title", value: [val], "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c110 = "from",
+        peg$c111 = peg$literalExpectation("from", false),
+        peg$c112 = "of",
+        peg$c113 = peg$literalExpectation("of", false),
+        peg$c114 = "in",
+        peg$c115 = peg$literalExpectation("in", false),
+        peg$c116 = "the",
+        peg$c117 = peg$literalExpectation("the", false),
+        peg$c118 = "book",
+        peg$c119 = peg$literalExpectation("book", false),
+        peg$c120 = /^[([]/,
+        peg$c121 = peg$classExpectation(["(", "["], false, false),
+        peg$c122 = /^[)\]]/,
+        peg$c123 = peg$classExpectation([")", "]"], false, false),
+        peg$c124 = function(val) { return {"type": "translation_sequence", "value": val, "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c125 = "\x1E",
+        peg$c126 = peg$literalExpectation("\x1E", false),
+        peg$c127 = function(val) { return {"type": "translation", "value": val.value, "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c128 = ",000",
+        peg$c129 = peg$literalExpectation(",000", false),
+        peg$c130 = function(val) { return {"type": "integer", "value": parseInt(val.join(""), 10), "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c131 = /^[^\x1F\x1E([]/,
+        peg$c132 = peg$classExpectation(["\x1F", "\x1E", "(", "["], true, false),
+        peg$c133 = function(val) { return {"type": "word", "value": val.join(""), "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c134 = function(val) { return {"type": "stop", "value": val, "indices": [peg$savedPos, peg$currPos - 1]} },
+        peg$c135 = /^[\s\xa0*]/,
+        peg$c136 = peg$classExpectation([" ", "\t", "\r", "\n", "\xA0", "*"], false, false),
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -3175,7 +3185,7 @@ var grammar;
 
     if ("punctuation_strategy" in options && options.punctuation_strategy === "eu") {
         peg$parsecv_sep = peg$parseeu_cv_sep;
-        peg$c80 = /^[;\/:&\-\u2013\u2014~]/;
+        peg$c86 = /^[;\/:&\-\u2013\u2014~]/;
     }
 
     function text() {
@@ -5294,7 +5304,7 @@ var grammar;
     }
 
     function peg$parseff() {
-      var s0, s1, s2, s3, s4, s5, s6;
+      var s0, s1, s2, s3, s4, s5, s6, s7;
 
       s0 = peg$currPos;
       s1 = peg$parsebcv();
@@ -5333,31 +5343,52 @@ var grammar;
             if (peg$silentFails === 0) { peg$fail(peg$c41); }
           }
           if (s3 !== peg$FAILED) {
-            s4 = peg$parseabbrev();
-            if (s4 === peg$FAILED) {
-              s4 = null;
+            s4 = peg$currPos;
+            peg$silentFails++;
+            if (peg$c42.test(input.charAt(peg$currPos))) {
+              s5 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c43); }
+            }
+            peg$silentFails--;
+            if (s5 === peg$FAILED) {
+              s4 = void 0;
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
             }
             if (s4 !== peg$FAILED) {
-              s5 = peg$currPos;
-              peg$silentFails++;
-              if (peg$c42.test(input.charAt(peg$currPos))) {
-                s6 = input.charAt(peg$currPos);
-                peg$currPos++;
-              } else {
-                s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c43); }
-              }
-              peg$silentFails--;
-              if (s6 === peg$FAILED) {
-                s5 = void 0;
-              } else {
-                peg$currPos = s5;
-                s5 = peg$FAILED;
+              s5 = peg$parseabbrev();
+              if (s5 === peg$FAILED) {
+                s5 = null;
               }
               if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c44(s1);
-                s0 = s1;
+                s6 = peg$currPos;
+                peg$silentFails++;
+                if (peg$c44.test(input.charAt(peg$currPos))) {
+                  s7 = input.charAt(peg$currPos);
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c45); }
+                }
+                peg$silentFails--;
+                if (s7 === peg$FAILED) {
+                  s6 = void 0;
+                } else {
+                  peg$currPos = s6;
+                  s6 = peg$FAILED;
+                }
+                if (s6 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c46(s1);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -5391,7 +5422,7 @@ var grammar;
         s2 = peg$parsetitle();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c45(s1, s2);
+          s1 = peg$c47(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5419,16 +5450,16 @@ var grammar;
       if (s1 !== peg$FAILED) {
         s2 = peg$parseany_integer();
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c46) {
-            s3 = peg$c46;
+          if (input.substr(peg$currPos, 3) === peg$c48) {
+            s3 = peg$c48;
             peg$currPos += 3;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c47); }
+            if (peg$silentFails === 0) { peg$fail(peg$c49); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c48(s2);
+            s1 = peg$c50(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5460,12 +5491,12 @@ var grammar;
       if (s1 !== peg$FAILED) {
         s2 = peg$parseany_integer();
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c49) {
-            s3 = peg$c49;
+          if (input.substr(peg$currPos, 3) === peg$c51) {
+            s3 = peg$c51;
             peg$currPos += 3;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -5493,22 +5524,22 @@ var grammar;
       s0 = peg$currPos;
       s1 = peg$parseps151_b();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c51) {
-          s2 = peg$c51;
+        if (input.substr(peg$currPos, 2) === peg$c53) {
+          s2 = peg$c53;
           peg$currPos += 2;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c52); }
+          if (peg$silentFails === 0) { peg$fail(peg$c54); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
           peg$silentFails++;
-          if (peg$c53.test(input.charAt(peg$currPos))) {
+          if (peg$c55.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c56); }
           }
           peg$silentFails--;
           if (s4 === peg$FAILED) {
@@ -5519,7 +5550,7 @@ var grammar;
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c55(s1);
+            s1 = peg$c57(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5554,7 +5585,7 @@ var grammar;
           s3 = peg$parseinteger();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c56(s1, s3);
+            s1 = peg$c58(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5573,7 +5604,7 @@ var grammar;
     }
 
     function peg$parsev_letter() {
-      var s0, s1, s2, s3, s4, s5, s6, s7;
+      var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
       s0 = peg$currPos;
       s1 = peg$parsev_explicit();
@@ -5587,12 +5618,41 @@ var grammar;
           if (s3 !== peg$FAILED) {
             s4 = peg$currPos;
             peg$silentFails++;
+            s5 = peg$currPos;
             if (input.substr(peg$currPos, 2) === peg$c40) {
-              s5 = peg$c40;
+              s6 = peg$c40;
               peg$currPos += 2;
             } else {
-              s5 = peg$FAILED;
+              s6 = peg$FAILED;
               if (peg$silentFails === 0) { peg$fail(peg$c41); }
+            }
+            if (s6 !== peg$FAILED) {
+              s7 = peg$currPos;
+              peg$silentFails++;
+              if (peg$c42.test(input.charAt(peg$currPos))) {
+                s8 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s8 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c43); }
+              }
+              peg$silentFails--;
+              if (s8 === peg$FAILED) {
+                s7 = void 0;
+              } else {
+                peg$currPos = s7;
+                s7 = peg$FAILED;
+              }
+              if (s7 !== peg$FAILED) {
+                s6 = [s6, s7];
+                s5 = s6;
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
             }
             peg$silentFails--;
             if (s5 === peg$FAILED) {
@@ -5602,22 +5662,22 @@ var grammar;
               s4 = peg$FAILED;
             }
             if (s4 !== peg$FAILED) {
-              if (peg$c57.test(input.charAt(peg$currPos))) {
+              if (peg$c59.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c58); }
+                if (peg$silentFails === 0) { peg$fail(peg$c60); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$currPos;
                 peg$silentFails++;
-                if (peg$c42.test(input.charAt(peg$currPos))) {
+                if (peg$c44.test(input.charAt(peg$currPos))) {
                   s7 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c43); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c45); }
                 }
                 peg$silentFails--;
                 if (s7 === peg$FAILED) {
@@ -5628,7 +5688,7 @@ var grammar;
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c59(s2);
+                  s1 = peg$c61(s2);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5670,7 +5730,7 @@ var grammar;
         s2 = peg$parseinteger();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c59(s2);
+          s1 = peg$c61(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5691,25 +5751,43 @@ var grammar;
       s1 = peg$parsesp();
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
-        if (input.substr(peg$currPos, 3) === peg$c60) {
-          s3 = peg$c60;
+        if (input.substr(peg$currPos, 3) === peg$c62) {
+          s3 = peg$c62;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c61); }
+          if (peg$silentFails === 0) { peg$fail(peg$c63); }
         }
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 4) === peg$c62) {
-            s4 = peg$c62;
-            peg$currPos += 4;
+          if (input.substr(peg$currPos, 5) === peg$c64) {
+            s4 = peg$c64;
+            peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c63); }
+            if (peg$silentFails === 0) { peg$fail(peg$c65); }
           }
           if (s4 === peg$FAILED) {
-            s4 = peg$parseabbrev();
+            if (input.substr(peg$currPos, 5) === peg$c64) {
+              s4 = peg$c64;
+              peg$currPos += 5;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c65); }
+            }
             if (s4 === peg$FAILED) {
-              s4 = null;
+              if (input.substr(peg$currPos, 4) === peg$c66) {
+                s4 = peg$c66;
+                peg$currPos += 4;
+              } else {
+                s4 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c67); }
+              }
+              if (s4 === peg$FAILED) {
+                s4 = peg$parseabbrev();
+                if (s4 === peg$FAILED) {
+                  s4 = null;
+                }
+              }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -5727,7 +5805,7 @@ var grammar;
           s3 = peg$parsesp();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c64();
+            s1 = peg$c68();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5753,78 +5831,44 @@ var grammar;
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 118) {
-          s3 = peg$c65;
+          s3 = peg$c69;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c70); }
         }
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 4) === peg$c67) {
-            s4 = peg$c67;
-            peg$currPos += 4;
+          if (input.substr(peg$currPos, 5) === peg$c71) {
+            s4 = peg$c71;
+            peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c68); }
+            if (peg$silentFails === 0) { peg$fail(peg$c72); }
           }
           if (s4 === peg$FAILED) {
-            s4 = peg$currPos;
-            if (input.substr(peg$currPos, 3) === peg$c69) {
-              s5 = peg$c69;
-              peg$currPos += 3;
+            if (input.substr(peg$currPos, 5) === peg$c73) {
+              s4 = peg$c73;
+              peg$currPos += 5;
             } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c70); }
-            }
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parseabbrev();
-              if (s6 === peg$FAILED) {
-                s6 = null;
-              }
-              if (s6 !== peg$FAILED) {
-                s5 = [s5, s6];
-                s4 = s5;
-              } else {
-                peg$currPos = s4;
-                s4 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s4;
               s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c74); }
             }
             if (s4 === peg$FAILED) {
-              s4 = peg$currPos;
-              if (input.substr(peg$currPos, 2) === peg$c71) {
-                s5 = peg$c71;
-                peg$currPos += 2;
+              if (input.substr(peg$currPos, 4) === peg$c75) {
+                s4 = peg$c75;
+                peg$currPos += 4;
               } else {
-                s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c72); }
-              }
-              if (s5 !== peg$FAILED) {
-                s6 = peg$parseabbrev();
-                if (s6 === peg$FAILED) {
-                  s6 = null;
-                }
-                if (s6 !== peg$FAILED) {
-                  s5 = [s5, s6];
-                  s4 = s5;
-                } else {
-                  peg$currPos = s4;
-                  s4 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s4;
                 s4 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c76); }
               }
               if (s4 === peg$FAILED) {
                 s4 = peg$currPos;
-                if (input.charCodeAt(peg$currPos) === 115) {
-                  s5 = peg$c73;
-                  peg$currPos++;
+                if (input.substr(peg$currPos, 3) === peg$c77) {
+                  s5 = peg$c77;
+                  peg$currPos += 3;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c78); }
                 }
                 if (s5 !== peg$FAILED) {
                   s6 = peg$parseabbrev();
@@ -5841,6 +5885,41 @@ var grammar;
                 } else {
                   peg$currPos = s4;
                   s4 = peg$FAILED;
+                }
+                if (s4 === peg$FAILED) {
+                  if (input.substr(peg$currPos, 3) === peg$c77) {
+                    s4 = peg$c77;
+                    peg$currPos += 3;
+                  } else {
+                    s4 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c78); }
+                  }
+                  if (s4 === peg$FAILED) {
+                    s4 = peg$currPos;
+                    if (input.charCodeAt(peg$currPos) === 115) {
+                      s5 = peg$c79;
+                      peg$currPos++;
+                    } else {
+                      s5 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+                    }
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parseabbrev();
+                      if (s6 === peg$FAILED) {
+                        s6 = null;
+                      }
+                      if (s6 !== peg$FAILED) {
+                        s5 = [s5, s6];
+                        s4 = s5;
+                      } else {
+                        peg$currPos = s4;
+                        s4 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s4;
+                      s4 = peg$FAILED;
+                    }
+                  }
                 }
               }
             }
@@ -5859,12 +5938,12 @@ var grammar;
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
           peg$silentFails++;
-          if (peg$c42.test(input.charAt(peg$currPos))) {
+          if (peg$c44.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c43); }
+            if (peg$silentFails === 0) { peg$fail(peg$c45); }
           }
           peg$silentFails--;
           if (s4 === peg$FAILED) {
@@ -5877,7 +5956,7 @@ var grammar;
             s4 = peg$parsesp();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c75();
+              s1 = peg$c81();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5907,21 +5986,21 @@ var grammar;
       if (s1 !== peg$FAILED) {
         s2 = [];
         if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c76;
+          s3 = peg$c82;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c77); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
             if (input.charCodeAt(peg$currPos) === 58) {
-              s3 = peg$c76;
+              s3 = peg$c82;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c77); }
+              if (peg$silentFails === 0) { peg$fail(peg$c83); }
             }
           }
         } else {
@@ -6024,12 +6103,12 @@ var grammar;
       s0 = peg$currPos;
       s1 = peg$parsesp();
       if (s1 !== peg$FAILED) {
-        if (peg$c78.test(input.charAt(peg$currPos))) {
+        if (peg$c84.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsesp();
@@ -6060,12 +6139,12 @@ var grammar;
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c80.test(input.charAt(peg$currPos))) {
+      if (peg$c86.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
@@ -6137,30 +6216,83 @@ var grammar;
           s2 = peg$FAILED;
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c82) {
-            s2 = peg$c82;
+          s2 = peg$currPos;
+          if (input.substr(peg$currPos, 3) === peg$c88) {
+            s3 = peg$c88;
             peg$currPos += 3;
           } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c89); }
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parsespace();
+            if (s4 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 5) === peg$c90) {
+                s5 = peg$c90;
+                peg$currPos += 5;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c91); }
+              }
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parsespace();
+                if (s6 !== peg$FAILED) {
+                  if (input.substr(peg$currPos, 4) === peg$c92) {
+                    s7 = peg$c92;
+                    peg$currPos += 4;
+                  } else {
+                    s7 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                  }
+                  if (s7 !== peg$FAILED) {
+                    s3 = [s3, s4, s5, s6, s7];
+                    s2 = s3;
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c83); }
           }
           if (s2 === peg$FAILED) {
             s2 = peg$currPos;
-            if (input.substr(peg$currPos, 3) === peg$c84) {
-              s3 = peg$c84;
+            if (input.substr(peg$currPos, 3) === peg$c88) {
+              s3 = peg$c88;
               peg$currPos += 3;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c85); }
+              if (peg$silentFails === 0) { peg$fail(peg$c89); }
             }
             if (s3 !== peg$FAILED) {
-              s4 = peg$parseabbrev();
-              if (s4 === peg$FAILED) {
-                s4 = null;
-              }
+              s4 = peg$parsespace();
               if (s4 !== peg$FAILED) {
-                s3 = [s3, s4];
-                s2 = s3;
+                if (input.substr(peg$currPos, 5) === peg$c90) {
+                  s5 = peg$c90;
+                  peg$currPos += 5;
+                } else {
+                  s5 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c91); }
+                }
+                if (s5 !== peg$FAILED) {
+                  s3 = [s3, s4, s5];
+                  s2 = s3;
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s2;
                 s2 = peg$FAILED;
@@ -6170,7 +6302,191 @@ var grammar;
               s2 = peg$FAILED;
             }
             if (s2 === peg$FAILED) {
-              s2 = peg$parsespace();
+              s2 = peg$currPos;
+              if (input.substr(peg$currPos, 3) === peg$c88) {
+                s3 = peg$c88;
+                peg$currPos += 3;
+              } else {
+                s3 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c89); }
+              }
+              if (s3 !== peg$FAILED) {
+                s4 = peg$parsespace();
+                if (s4 !== peg$FAILED) {
+                  if (input.substr(peg$currPos, 4) === peg$c92) {
+                    s5 = peg$c92;
+                    peg$currPos += 4;
+                  } else {
+                    s5 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                  }
+                  if (s5 !== peg$FAILED) {
+                    s3 = [s3, s4, s5];
+                    s2 = s3;
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+              if (s2 === peg$FAILED) {
+                s2 = peg$currPos;
+                if (input.substr(peg$currPos, 5) === peg$c94) {
+                  s3 = peg$c94;
+                  peg$currPos += 5;
+                } else {
+                  s3 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c95); }
+                }
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parsespace();
+                  if (s4 !== peg$FAILED) {
+                    if (input.substr(peg$currPos, 4) === peg$c92) {
+                      s5 = peg$c92;
+                      peg$currPos += 4;
+                    } else {
+                      s5 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                    }
+                    if (s5 !== peg$FAILED) {
+                      s3 = [s3, s4, s5];
+                      s2 = s3;
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+                if (s2 === peg$FAILED) {
+                  s2 = peg$currPos;
+                  if (input.substr(peg$currPos, 5) === peg$c90) {
+                    s3 = peg$c90;
+                    peg$currPos += 5;
+                  } else {
+                    s3 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c91); }
+                  }
+                  if (s3 !== peg$FAILED) {
+                    s4 = peg$parsespace();
+                    if (s4 !== peg$FAILED) {
+                      if (input.substr(peg$currPos, 4) === peg$c92) {
+                        s5 = peg$c92;
+                        peg$currPos += 4;
+                      } else {
+                        s5 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                      }
+                      if (s5 !== peg$FAILED) {
+                        s3 = [s3, s4, s5];
+                        s2 = s3;
+                      } else {
+                        peg$currPos = s2;
+                        s2 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                  if (s2 === peg$FAILED) {
+                    if (input.substr(peg$currPos, 5) === peg$c90) {
+                      s2 = peg$c90;
+                      peg$currPos += 5;
+                    } else {
+                      s2 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c91); }
+                    }
+                    if (s2 === peg$FAILED) {
+                      if (input.substr(peg$currPos, 5) === peg$c94) {
+                        s2 = peg$c94;
+                        peg$currPos += 5;
+                      } else {
+                        s2 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c95); }
+                      }
+                      if (s2 === peg$FAILED) {
+                        s2 = peg$currPos;
+                        if (input.charCodeAt(peg$currPos) === 117) {
+                          s3 = peg$c96;
+                          peg$currPos++;
+                        } else {
+                          s3 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c97); }
+                        }
+                        if (s3 !== peg$FAILED) {
+                          s4 = peg$parseabbrev();
+                          if (s4 === peg$FAILED) {
+                            s4 = null;
+                          }
+                          if (s4 !== peg$FAILED) {
+                            s3 = [s3, s4];
+                            s2 = s3;
+                          } else {
+                            peg$currPos = s2;
+                            s2 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s2;
+                          s2 = peg$FAILED;
+                        }
+                        if (s2 === peg$FAILED) {
+                          if (input.charCodeAt(peg$currPos) === 38) {
+                            s2 = peg$c98;
+                            peg$currPos++;
+                          } else {
+                            s2 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c99); }
+                          }
+                          if (s2 === peg$FAILED) {
+                            s2 = peg$currPos;
+                            if (input.substr(peg$currPos, 3) === peg$c100) {
+                              s3 = peg$c100;
+                              peg$currPos += 3;
+                            } else {
+                              s3 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c101); }
+                            }
+                            if (s3 !== peg$FAILED) {
+                              s4 = peg$parseabbrev();
+                              if (s4 === peg$FAILED) {
+                                s4 = null;
+                              }
+                              if (s4 !== peg$FAILED) {
+                                s3 = [s3, s4];
+                                s2 = s3;
+                              } else {
+                                peg$currPos = s2;
+                                s2 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s2;
+                              s2 = peg$FAILED;
+                            }
+                            if (s2 === peg$FAILED) {
+                              s2 = peg$parsespace();
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -6178,12 +6494,12 @@ var grammar;
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c80.test(input.charAt(peg$currPos))) {
+          if (peg$c86.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c81); }
+            if (peg$silentFails === 0) { peg$fail(peg$c87); }
           }
           if (s2 === peg$FAILED) {
             s2 = peg$currPos;
@@ -6255,30 +6571,83 @@ var grammar;
               s2 = peg$FAILED;
             }
             if (s2 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c82) {
-                s2 = peg$c82;
+              s2 = peg$currPos;
+              if (input.substr(peg$currPos, 3) === peg$c88) {
+                s3 = peg$c88;
                 peg$currPos += 3;
               } else {
+                s3 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c89); }
+              }
+              if (s3 !== peg$FAILED) {
+                s4 = peg$parsespace();
+                if (s4 !== peg$FAILED) {
+                  if (input.substr(peg$currPos, 5) === peg$c90) {
+                    s5 = peg$c90;
+                    peg$currPos += 5;
+                  } else {
+                    s5 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c91); }
+                  }
+                  if (s5 !== peg$FAILED) {
+                    s6 = peg$parsespace();
+                    if (s6 !== peg$FAILED) {
+                      if (input.substr(peg$currPos, 4) === peg$c92) {
+                        s7 = peg$c92;
+                        peg$currPos += 4;
+                      } else {
+                        s7 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                      }
+                      if (s7 !== peg$FAILED) {
+                        s3 = [s3, s4, s5, s6, s7];
+                        s2 = s3;
+                      } else {
+                        peg$currPos = s2;
+                        s2 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c83); }
               }
               if (s2 === peg$FAILED) {
                 s2 = peg$currPos;
-                if (input.substr(peg$currPos, 3) === peg$c84) {
-                  s3 = peg$c84;
+                if (input.substr(peg$currPos, 3) === peg$c88) {
+                  s3 = peg$c88;
                   peg$currPos += 3;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c85); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c89); }
                 }
                 if (s3 !== peg$FAILED) {
-                  s4 = peg$parseabbrev();
-                  if (s4 === peg$FAILED) {
-                    s4 = null;
-                  }
+                  s4 = peg$parsespace();
                   if (s4 !== peg$FAILED) {
-                    s3 = [s3, s4];
-                    s2 = s3;
+                    if (input.substr(peg$currPos, 5) === peg$c90) {
+                      s5 = peg$c90;
+                      peg$currPos += 5;
+                    } else {
+                      s5 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c91); }
+                    }
+                    if (s5 !== peg$FAILED) {
+                      s3 = [s3, s4, s5];
+                      s2 = s3;
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
                   } else {
                     peg$currPos = s2;
                     s2 = peg$FAILED;
@@ -6288,7 +6657,191 @@ var grammar;
                   s2 = peg$FAILED;
                 }
                 if (s2 === peg$FAILED) {
-                  s2 = peg$parsespace();
+                  s2 = peg$currPos;
+                  if (input.substr(peg$currPos, 3) === peg$c88) {
+                    s3 = peg$c88;
+                    peg$currPos += 3;
+                  } else {
+                    s3 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c89); }
+                  }
+                  if (s3 !== peg$FAILED) {
+                    s4 = peg$parsespace();
+                    if (s4 !== peg$FAILED) {
+                      if (input.substr(peg$currPos, 4) === peg$c92) {
+                        s5 = peg$c92;
+                        peg$currPos += 4;
+                      } else {
+                        s5 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                      }
+                      if (s5 !== peg$FAILED) {
+                        s3 = [s3, s4, s5];
+                        s2 = s3;
+                      } else {
+                        peg$currPos = s2;
+                        s2 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                  if (s2 === peg$FAILED) {
+                    s2 = peg$currPos;
+                    if (input.substr(peg$currPos, 5) === peg$c94) {
+                      s3 = peg$c94;
+                      peg$currPos += 5;
+                    } else {
+                      s3 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c95); }
+                    }
+                    if (s3 !== peg$FAILED) {
+                      s4 = peg$parsespace();
+                      if (s4 !== peg$FAILED) {
+                        if (input.substr(peg$currPos, 4) === peg$c92) {
+                          s5 = peg$c92;
+                          peg$currPos += 4;
+                        } else {
+                          s5 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                        }
+                        if (s5 !== peg$FAILED) {
+                          s3 = [s3, s4, s5];
+                          s2 = s3;
+                        } else {
+                          peg$currPos = s2;
+                          s2 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s2;
+                        s2 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                    if (s2 === peg$FAILED) {
+                      s2 = peg$currPos;
+                      if (input.substr(peg$currPos, 5) === peg$c90) {
+                        s3 = peg$c90;
+                        peg$currPos += 5;
+                      } else {
+                        s3 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c91); }
+                      }
+                      if (s3 !== peg$FAILED) {
+                        s4 = peg$parsespace();
+                        if (s4 !== peg$FAILED) {
+                          if (input.substr(peg$currPos, 4) === peg$c92) {
+                            s5 = peg$c92;
+                            peg$currPos += 4;
+                          } else {
+                            s5 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                          }
+                          if (s5 !== peg$FAILED) {
+                            s3 = [s3, s4, s5];
+                            s2 = s3;
+                          } else {
+                            peg$currPos = s2;
+                            s2 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s2;
+                          s2 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s2;
+                        s2 = peg$FAILED;
+                      }
+                      if (s2 === peg$FAILED) {
+                        if (input.substr(peg$currPos, 5) === peg$c90) {
+                          s2 = peg$c90;
+                          peg$currPos += 5;
+                        } else {
+                          s2 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+                        }
+                        if (s2 === peg$FAILED) {
+                          if (input.substr(peg$currPos, 5) === peg$c94) {
+                            s2 = peg$c94;
+                            peg$currPos += 5;
+                          } else {
+                            s2 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c95); }
+                          }
+                          if (s2 === peg$FAILED) {
+                            s2 = peg$currPos;
+                            if (input.charCodeAt(peg$currPos) === 117) {
+                              s3 = peg$c96;
+                              peg$currPos++;
+                            } else {
+                              s3 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c97); }
+                            }
+                            if (s3 !== peg$FAILED) {
+                              s4 = peg$parseabbrev();
+                              if (s4 === peg$FAILED) {
+                                s4 = null;
+                              }
+                              if (s4 !== peg$FAILED) {
+                                s3 = [s3, s4];
+                                s2 = s3;
+                              } else {
+                                peg$currPos = s2;
+                                s2 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s2;
+                              s2 = peg$FAILED;
+                            }
+                            if (s2 === peg$FAILED) {
+                              if (input.charCodeAt(peg$currPos) === 38) {
+                                s2 = peg$c98;
+                                peg$currPos++;
+                              } else {
+                                s2 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c99); }
+                              }
+                              if (s2 === peg$FAILED) {
+                                s2 = peg$currPos;
+                                if (input.substr(peg$currPos, 3) === peg$c100) {
+                                  s3 = peg$c100;
+                                  peg$currPos += 3;
+                                } else {
+                                  s3 = peg$FAILED;
+                                  if (peg$silentFails === 0) { peg$fail(peg$c101); }
+                                }
+                                if (s3 !== peg$FAILED) {
+                                  s4 = peg$parseabbrev();
+                                  if (s4 === peg$FAILED) {
+                                    s4 = null;
+                                  }
+                                  if (s4 !== peg$FAILED) {
+                                    s3 = [s3, s4];
+                                    s2 = s3;
+                                  } else {
+                                    peg$currPos = s2;
+                                    s2 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s2;
+                                  s2 = peg$FAILED;
+                                }
+                                if (s2 === peg$FAILED) {
+                                  s2 = peg$parsespace();
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6299,7 +6852,7 @@ var grammar;
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c86();
+        s1 = peg$c102();
       }
       s0 = s1;
 
@@ -6314,12 +6867,12 @@ var grammar;
       if (s1 !== peg$FAILED) {
         s2 = [];
         s3 = peg$currPos;
-        if (peg$c87.test(input.charAt(peg$currPos))) {
+        if (peg$c103.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c88); }
+          if (peg$silentFails === 0) { peg$fail(peg$c104); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsesp();
@@ -6336,12 +6889,12 @@ var grammar;
         }
         if (s3 === peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 3) === peg$c89) {
-            s4 = peg$c89;
+          if (input.substr(peg$currPos, 3) === peg$c105) {
+            s4 = peg$c105;
             peg$currPos += 3;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c90); }
+            if (peg$silentFails === 0) { peg$fail(peg$c106); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parsesp();
@@ -6361,12 +6914,12 @@ var grammar;
           while (s3 !== peg$FAILED) {
             s2.push(s3);
             s3 = peg$currPos;
-            if (peg$c87.test(input.charAt(peg$currPos))) {
+            if (peg$c103.test(input.charAt(peg$currPos))) {
               s4 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c88); }
+              if (peg$silentFails === 0) { peg$fail(peg$c104); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parsesp();
@@ -6383,12 +6936,12 @@ var grammar;
             }
             if (s3 === peg$FAILED) {
               s3 = peg$currPos;
-              if (input.substr(peg$currPos, 3) === peg$c89) {
-                s4 = peg$c89;
+              if (input.substr(peg$currPos, 3) === peg$c105) {
+                s4 = peg$c105;
                 peg$currPos += 3;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c90); }
+                if (peg$silentFails === 0) { peg$fail(peg$c106); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = peg$parsesp();
@@ -6435,16 +6988,16 @@ var grammar;
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c91) {
-          s2 = peg$c91;
+        if (input.substr(peg$currPos, 5) === peg$c107) {
+          s2 = peg$c107;
           peg$currPos += 5;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c92); }
+          if (peg$silentFails === 0) { peg$fail(peg$c108); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c93(s2);
+          s1 = peg$c109(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6464,28 +7017,28 @@ var grammar;
       s0 = peg$currPos;
       s1 = peg$parsesp();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c94) {
-          s2 = peg$c94;
+        if (input.substr(peg$currPos, 4) === peg$c110) {
+          s2 = peg$c110;
           peg$currPos += 4;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c95); }
+          if (peg$silentFails === 0) { peg$fail(peg$c111); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c96) {
-            s2 = peg$c96;
+          if (input.substr(peg$currPos, 2) === peg$c112) {
+            s2 = peg$c112;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c97); }
+            if (peg$silentFails === 0) { peg$fail(peg$c113); }
           }
           if (s2 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c98) {
-              s2 = peg$c98;
+            if (input.substr(peg$currPos, 2) === peg$c114) {
+              s2 = peg$c114;
               peg$currPos += 2;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c99); }
+              if (peg$silentFails === 0) { peg$fail(peg$c115); }
             }
           }
         }
@@ -6493,32 +7046,32 @@ var grammar;
           s3 = peg$parsesp();
           if (s3 !== peg$FAILED) {
             s4 = peg$currPos;
-            if (input.substr(peg$currPos, 3) === peg$c100) {
-              s5 = peg$c100;
+            if (input.substr(peg$currPos, 3) === peg$c116) {
+              s5 = peg$c116;
               peg$currPos += 3;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              if (peg$silentFails === 0) { peg$fail(peg$c117); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parsesp();
               if (s6 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 4) === peg$c102) {
-                  s7 = peg$c102;
+                if (input.substr(peg$currPos, 4) === peg$c118) {
+                  s7 = peg$c118;
                   peg$currPos += 4;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c103); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c119); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parsesp();
                   if (s8 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c96) {
-                      s9 = peg$c96;
+                    if (input.substr(peg$currPos, 2) === peg$c112) {
+                      s9 = peg$c112;
                       peg$currPos += 2;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c97); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c113); }
                     }
                     if (s9 !== peg$FAILED) {
                       s10 = peg$parsesp();
@@ -6696,12 +7249,12 @@ var grammar;
       s0 = peg$currPos;
       s1 = peg$parsesp();
       if (s1 !== peg$FAILED) {
-        if (peg$c104.test(input.charAt(peg$currPos))) {
+        if (peg$c120.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c105); }
+          if (peg$silentFails === 0) { peg$fail(peg$c121); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsesp();
@@ -6757,16 +7310,16 @@ var grammar;
             if (s4 !== peg$FAILED) {
               s5 = peg$parsesp();
               if (s5 !== peg$FAILED) {
-                if (peg$c106.test(input.charAt(peg$currPos))) {
+                if (peg$c122.test(input.charAt(peg$currPos))) {
                   s6 = input.charAt(peg$currPos);
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c107); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c123); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c108(s4);
+                  s1 = peg$c124(s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6877,7 +7430,7 @@ var grammar;
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c108(s3);
+            s1 = peg$c124(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6900,25 +7453,25 @@ var grammar;
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 30) {
-        s1 = peg$c109;
+        s1 = peg$c125;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+        if (peg$silentFails === 0) { peg$fail(peg$c126); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseany_integer();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 30) {
-            s3 = peg$c109;
+            s3 = peg$c125;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c126); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c111(s2);
+            s1 = peg$c127(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6952,22 +7505,22 @@ var grammar;
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c53.test(input.charAt(peg$currPos))) {
+      if (peg$c55.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c56); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c53.test(input.charAt(peg$currPos))) {
+          if (peg$c55.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c56); }
           }
         }
       } else {
@@ -6975,7 +7528,7 @@ var grammar;
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1);
+        s1 = peg$c130(s1);
       }
       s0 = s1;
 
@@ -6987,22 +7540,22 @@ var grammar;
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c115.test(input.charAt(peg$currPos))) {
+      if (peg$c131.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c116); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c115.test(input.charAt(peg$currPos))) {
+          if (peg$c131.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c116); }
+            if (peg$silentFails === 0) { peg$fail(peg$c132); }
           }
         }
       } else {
@@ -7010,7 +7563,7 @@ var grammar;
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c117(s1);
+        s1 = peg$c133(s1);
       }
       s0 = s1;
 
@@ -7021,16 +7574,16 @@ var grammar;
       var s0, s1;
 
       s0 = peg$currPos;
-      if (peg$c104.test(input.charAt(peg$currPos))) {
+      if (peg$c120.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c121); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c118(s1);
+        s1 = peg$c134(s1);
       }
       s0 = s1;
 

--- a/package.json
+++ b/package.json
@@ -24,5 +24,17 @@
   "bugs": {
     "url": "https://github.com/openbibleinfo/Bible-Passage-Reference-Parser/issues"
   },
-  "homepage": "https://github.com/openbibleinfo/Bible-Passage-Reference-Parser"
+  "homepage": "https://github.com/openbibleinfo/Bible-Passage-Reference-Parser",
+  "scripts": {
+    "add-language": "cd bin && perl 01.add_lang.pl",
+    "build-language": "cd bin && perl 02.compile.pl",
+    "test-language": "bash -c 'jasmine-node test/js/$0.spec.js'",
+    "test": "find test/js -name *.spec.js | xargs -I % sh -c 'echo %; jasmine-node %'; ] || exit 1;"
+  },
+  "devDependencies": {
+    "coffeescript": "^1.x",
+    "jasmine-node": "^1.15.0",
+    "pegjs": "^0.10.0",
+    "regexgen": "^1.3.0"
+  }
 }

--- a/src/de/book_names.txt
+++ b/src/de/book_names.txt
@@ -1,30 +1,63 @@
+1Chr	Ersten Chronik
+1Chr	Erster Chronik
+1Chr	Erstes Chronik
 1Chr	Erste Chronik
 1Chr	1. Chronik
 1Chr	1 Chronik
+1Chr	1. Chron
+1Chr	1 Chron
 1Chr	1. Chr
 1Chr	1 Chr
 1Chr	1Chr
+1Cor	Ersten Korinther
+1Cor	Erster Korinther
+1Cor	Erstes Korinther
 1Cor	Erste Korinther
 1Cor	1. Korinther
 1Cor	1 Korinther
 1Cor	1. Kor
 1Cor	1 Kor
 1Cor	1Cor
+1Esd	Ersten Esdra
+1Esd	Erster Esdra
+1Esd	Erstes Esdra
+1Esd	Erste Esdra
+1Esd	Ersten Esra
+1Esd	Erster Esra
+1Esd	Erstes Esra
 1Esd	Erste Esra
+1Esd	1. Esdra
+1Esd	1 Esdra
+1Esd	1. Esdr
 1Esd	1. Esra
+1Esd	1 Esdr
 1Esd	1 Esra
 1Esd	1. Esr
 1Esd	1 Esr
 1Esd	1. Es
 1Esd	1 Es
 1Esd	1Esd
+1John	Ersten Johannes
+1John	Erster Johannes
+1John	Erstes Johannes
 1John	Erste Johannes
 1John	1. Johannes
 1John	1 Johannes
 1John	1. Joh
 1John	1 Joh
+1John	1. Jo
 1John	1John
+1John	1 Jo
+1Kgs	Ersten Koenige
+1Kgs	Erster Koenige
+1Kgs	Erstes Koenige
 1Kgs	Erste Koenige
+1Kgs	Ersten Konige
+1Kgs	Ersten Könige
+1Kgs	Erster Konige
+1Kgs	Erster Könige
+1Kgs	Erstes Konige
+1Kgs	Erstes Könige
 1Kgs	Erste Konige
 1Kgs	Erste Könige
 1Kgs	1. Koenige
@@ -33,13 +66,35 @@
 1Kgs	1. Könige
 1Kgs	1 Konige
 1Kgs	1 Könige
+1Kgs	1. Koen
+1Kgs	1 Koen
+1Kgs	1. Kng
+1Kgs	1. Koe
 1Kgs	1. Kon
 1Kgs	1. Kön
+1Kgs	1 Kng
+1Kgs	1 Koe
 1Kgs	1 Kon
 1Kgs	1 Kön
+1Kgs	1. Ko
+1Kgs	1. Kö
+1Kgs	1 Ko
+1Kgs	1 Kö
 1Kgs	1Kgs
+1Macc	Ersten Makkabaeer
+1Macc	Erster Makkabaeer
+1Macc	Erstes Makkabaeer
+1Macc	Erste Makkabaeer
+1Macc	Ersten Makkabaer
+1Macc	Ersten Makkabäer
+1Macc	Erster Makkabaer
+1Macc	Erster Makkabäer
+1Macc	Erstes Makkabaer
+1Macc	Erstes Makkabäer
 1Macc	Erste Makkabaer
 1Macc	Erste Makkabäer
+1Macc	1. Makkabaeer
+1Macc	1 Makkabaeer
 1Macc	1. Makkabaer
 1Macc	1. Makkabäer
 1Macc	1 Makkabaer
@@ -47,57 +102,110 @@
 1Macc	1. Makk
 1Macc	1 Makk
 1Macc	1Macc
+1Pet	Ersten Petrus
+1Pet	Erster Petrus
+1Pet	Erstes Petrus
 1Pet	Erste Petrus
 1Pet	1. Petrus
 1Pet	1 Petrus
 1Pet	1. Petr
 1Pet	1 Petr
+1Pet	1. Pet
+1Pet	1 Pet
+1Pet	1. Pt
+1Pet	1 Pt
 1Pet	1Pet
+1Sam	Ersten Samuel
+1Sam	Erster Samuel
+1Sam	Erstes Samuel
 1Sam	Erste Samuel
 1Sam	1. Samuel
 1Sam	1 Samuel
 1Sam	1. Sam
 1Sam	1 Sam
+1Sam	1. Sa
+1Sam	1 Sa
 1Sam	1Sam
+1Thess	Ersten Thessalonicher
+1Thess	Erster Thessalonicher
+1Thess	Erstes Thessalonicher
 1Thess	Erste Thessalonicher
 1Thess	1. Thessalonicher
 1Thess	1 Thessalonicher
 1Thess	1. Thess
 1Thess	1 Thess
 1Thess	1Thess
+1Thess	1. Th
+1Thess	1 Th
+1Tim	Ersten Timotheus
+1Tim	Erster Timotheus
+1Tim	Erstes Timotheus
 1Tim	Erste Timotheus
 1Tim	1. Timotheus
 1Tim	1 Timotheus
 1Tim	1. Tim
 1Tim	1 Tim
 1Tim	1Tim
+2Chr	Zweiten Chronik
+2Chr	Zweiter Chronik
+2Chr	Zweites Chronik
 2Chr	Zweite Chronik
 2Chr	2. Chronik
 2Chr	2 Chronik
+2Chr	2. Chron
+2Chr	2 Chron
 2Chr	2. Chr
 2Chr	2 Chr
 2Chr	2Chr
+2Cor	Zweiten Korinther
+2Cor	Zweiter Korinther
+2Cor	Zweites Korinther
 2Cor	Zweite Korinther
 2Cor	2. Korinther
 2Cor	2 Korinther
 2Cor	2. Kor
 2Cor	2 Kor
 2Cor	2Cor
+2Esd	Zweiten Esdra
+2Esd	Zweiter Esdra
+2Esd	Zweites Esdra
+2Esd	Zweite Esdra
+2Esd	Zweiten Esra
+2Esd	Zweiter Esra
+2Esd	Zweites Esra
 2Esd	Zweite Esra
+2Esd	2. Esdra
+2Esd	2 Esdra
+2Esd	2. Esdr
 2Esd	2. Esra
+2Esd	2 Esdr
 2Esd	2 Esra
 2Esd	2. Esr
 2Esd	2 Esr
 2Esd	2. Es
 2Esd	2 Es
 2Esd	2Esd
+2John	Zweiten Johannes
+2John	Zweiter Johannes
+2John	Zweites Johannes
 2John	Zweite Johannes
 2John	2. Johannes
 2John	2 Johannes
 2John	2. Joh
 2John	2 Joh
+2John	2. Jo
 2John	2John
+2John	2 Jo
+2Kgs	Zweiten Koenige
+2Kgs	Zweiter Koenige
+2Kgs	Zweites Koenige
 2Kgs	Zweite Koenige
+2Kgs	Zweiten Konige
+2Kgs	Zweiten Könige
+2Kgs	Zweiter Konige
+2Kgs	Zweiter Könige
+2Kgs	Zweites Konige
+2Kgs	Zweites Könige
 2Kgs	Zweite Konige
 2Kgs	Zweite Könige
 2Kgs	2. Koenige
@@ -106,13 +214,35 @@
 2Kgs	2. Könige
 2Kgs	2 Konige
 2Kgs	2 Könige
+2Kgs	2. Koen
+2Kgs	2 Koen
+2Kgs	2. Kng
+2Kgs	2. Koe
 2Kgs	2. Kon
 2Kgs	2. Kön
+2Kgs	2 Kng
+2Kgs	2 Koe
 2Kgs	2 Kon
 2Kgs	2 Kön
+2Kgs	2. Ko
+2Kgs	2. Kö
+2Kgs	2 Ko
+2Kgs	2 Kö
 2Kgs	2Kgs
+2Macc	Zweiten Makkabaeer
+2Macc	Zweiter Makkabaeer
+2Macc	Zweites Makkabaeer
+2Macc	Zweite Makkabaeer
+2Macc	Zweiten Makkabaer
+2Macc	Zweiten Makkabäer
+2Macc	Zweiter Makkabaer
+2Macc	Zweiter Makkabäer
+2Macc	Zweites Makkabaer
+2Macc	Zweites Makkabäer
 2Macc	Zweite Makkabaer
 2Macc	Zweite Makkabäer
+2Macc	2. Makkabaeer
+2Macc	2 Makkabaeer
 2Macc	2. Makkabaer
 2Macc	2. Makkabäer
 2Macc	2 Makkabaer
@@ -120,38 +250,75 @@
 2Macc	2. Makk
 2Macc	2 Makk
 2Macc	2Macc
+2Pet	Zweiten Petrus
+2Pet	Zweiter Petrus
+2Pet	Zweites Petrus
 2Pet	Zweite Petrus
 2Pet	2. Petrus
 2Pet	2 Petrus
 2Pet	2. Petr
 2Pet	2 Petr
+2Pet	2. Pet
+2Pet	2 Pet
+2Pet	2. Pt
+2Pet	2 Pt
 2Pet	2Pet
+2Sam	Zweiten Samuel
+2Sam	Zweiter Samuel
+2Sam	Zweites Samuel
 2Sam	Zweite Samuel
 2Sam	2. Samuel
 2Sam	2 Samuel
 2Sam	2. Sam
 2Sam	2 Sam
+2Sam	2. Sa
+2Sam	2 Sa
 2Sam	2Sam
+2Thess	Zweiten Thessalonicher
+2Thess	Zweiter Thessalonicher
+2Thess	Zweites Thessalonicher
 2Thess	Zweite Thessalonicher
 2Thess	2. Thessalonicher
 2Thess	2 Thessalonicher
 2Thess	2. Thess
 2Thess	2 Thess
 2Thess	2Thess
+2Thess	2. Th
+2Thess	2 Th
+2Tim	Zweiten Timotheus
+2Tim	Zweiter Timotheus
+2Tim	Zweites Timotheus
 2Tim	Zweite Timotheus
 2Tim	2. Timotheus
 2Tim	2 Timotheus
 2Tim	2. Tim
 2Tim	2 Tim
 2Tim	2Tim
+3John	Dritten Johannes
+3John	Dritter Johannes
+3John	Drittes Johannes
 3John	Dritte Johannes
 3John	3. Johannes
 3John	3 Johannes
 3John	3. Joh
 3John	3 Joh
+3John	3. Jo
 3John	3John
+3John	3 Jo
+3Macc	Dritten Makkabaeer
+3Macc	Dritter Makkabaeer
+3Macc	Drittes Makkabaeer
+3Macc	Dritte Makkabaeer
+3Macc	Dritten Makkabaer
+3Macc	Dritten Makkabäer
+3Macc	Dritter Makkabaer
+3Macc	Dritter Makkabäer
+3Macc	Drittes Makkabaer
+3Macc	Drittes Makkabäer
 3Macc	Dritte Makkabaer
 3Macc	Dritte Makkabäer
+3Macc	3. Makkabaeer
+3Macc	3 Makkabaeer
 3Macc	3. Makkabaer
 3Macc	3. Makkabäer
 3Macc	3 Makkabaer
@@ -159,8 +326,17 @@
 3Macc	3. Makk
 3Macc	3 Makk
 3Macc	3Macc
+4Macc	Vierten Makkabaeer
+4Macc	Viertes Makkabaeer
+4Macc	Vierte Makkabaeer
+4Macc	Vierten Makkabaer
+4Macc	Vierten Makkabäer
+4Macc	Viertes Makkabaer
+4Macc	Viertes Makkabäer
 4Macc	Vierte Makkabaer
 4Macc	Vierte Makkabäer
+4Macc	4. Makkabaeer
+4Macc	4 Makkabaeer
 4Macc	4. Makkabaer
 4Macc	4. Makkabäer
 4Macc	4 Makkabaer
@@ -176,19 +352,21 @@ Amos	Am
 Bar	Baruch
 Bar	Bar
 Bel	Bel und Vom Drachen
+Bel	Bel und der Drache
+Bel	Bel und de Drache
 Bel	Bel
 Col	Kolosser
 Col	Col
 Col	Kol
 Dan	Daniel
 Dan	Dan
-Deut	Funfte Buch Mose
-Deut	Fünfte Buch Mose
+Deut	Funftes Buch Mose
+Deut	Fünftes Buch Mose
 Deut	Deuteronomium
 Deut	5. Buch Mose
+Deut	Funftes Mose
+Deut	Fünftes Mose
 Deut	5 Buch Mose
-Deut	Funfte Mose
-Deut	Fünfte Mose
 Deut	5. Mose
 Deut	5 Mose
 Deut	5. Mos
@@ -197,6 +375,7 @@ Deut	5. Mo
 Deut	5 Mo
 Deut	Deut
 Deut	Dtn
+Deut	Dt
 Eccl	Ecclesiastes
 Eccl	Ekklesiastes
 Eccl	Prediger
@@ -213,8 +392,14 @@ Esth	Esther
 Esth	Ester
 Esth	Esth
 Esth	Est
+Exod	Zweiten Buch Mose
+Exod	Zweiter Buch Mose
+Exod	Zweites Buch Mose
 Exod	Zweite Buch Mose
 Exod	2. Buch Mose
+Exod	Zweiten Mose
+Exod	Zweiter Mose
+Exod	Zweites Mose
 Exod	2 Buch Mose
 Exod	Zweite Mose
 Exod	2. Mose
@@ -228,18 +413,24 @@ Exod	Exod
 Exod	Ex
 Ezek	Ezechiel
 Ezek	Hesekiel
+Ezek	Hesek
 Ezek	Ezek
 Ezek	Hes
 Ezek	Ez
 Ezra	Esra
 Ezra	Ezra
 Ezra	Esr
-Ezra,Esth	Es
 Gal	Galater
 Gal	Gal
+Gen	Ersten Buch Mose
+Gen	Erster Buch Mose
+Gen	Erstes Buch Mose
 Gen	Erste Buch Mose
 Gen	1. Buch Mose
 Gen	1 Buch Mose
+Gen	Ersten Mose
+Gen	Erster Mose
+Gen	Erstes Mose
 Gen	Erste Mose
 Gen	1. Mose
 Gen	Genesis
@@ -249,25 +440,23 @@ Gen	1 Mos
 Gen	1. Mo
 Gen	1 Mo
 Gen	Gen
+Gen	Gn
 GkEsth	Ester \(Griechisch\)
 GkEsth	Ester (Griechisch)
 GkEsth	GkEsth
 GkEsth	Gr Est
 Hab	Habakuk
 Hab	Hab
-Hag	Aggaus
-Hag	Aggäus
 Hag	Haggai
-Hag	Agg
+Hag	Hagg
 Hag	Hag
-Hag	Ag
 Heb	Hebraeer
 Heb	Hebraer
 Heb	Hebräer
 Heb	Hebr
 Heb	Heb
+Heb	Hb
 Hos	Hosea
-Hos	Osee
 Hos	Hos
 Isa	Isaias
 Isa	Jesaja
@@ -277,6 +466,7 @@ Jas	Jakobusbrief
 Jas	Jakobus
 Jas	Jak
 Jas	Jas
+Jas	Jk
 Jdt	Judit
 Jdt	Jdt
 Jer	Jeremias
@@ -287,6 +477,9 @@ Job	Ijob
 Job	Job
 Job	Hi
 Joel	Joel
+John	Das Evangelium nach Johannes
+John	 Evangelium nach Johannes
+John	Johannesevangelium
 John	Johannes
 John	John
 John	Joh
@@ -301,14 +494,21 @@ Jude	Jude
 Jude	Jud
 Judg	Richter
 Judg	Judg
+Judg	Rich
 Judg	Ri
 Lam	Klagelieder Jeremias
 Lam	Klagelieder
 Lam	Klag
 Lam	Klgl
 Lam	Lam
+Lev	Dritten Buch Mose
+Lev	Dritter Buch Mose
+Lev	Drittes Buch Mose
 Lev	Dritte Buch Mose
 Lev	3. Buch Mose
+Lev	Dritten Mose
+Lev	Dritter Mose
+Lev	Drittes Mose
 Lev	3 Buch Mose
 Lev	Dritte Mose
 Lev	Levitikus
@@ -319,30 +519,54 @@ Lev	3 Mos
 Lev	3. Mo
 Lev	3 Mo
 Lev	Lev
+Lev	Lv
+Luke	Das Evangelium nach Lukas
+Luke	 Evangelium nach Lukas
+Luke	Lukasevangelium
 Luke	Lukas
 Luke	Luke
+Luke	Luk
 Luke	Lk
 Mal	Malachias
 Mal	Maleachi
 Mal	Mal
+Mark	Das Evangelium nach Markus
+Mark	 Evangelium nach Markus
+Mark	Markusevangelium
 Mark	Markus
 Mark	Mark
 Mark	Mk
+Matt	Das Evangelium nach Matthaeus
+Matt	Das Evangelium nach Matthaus
+Matt	Das Evangelium nach Matthäus
+Matt	 Evangelium nach Matthaeus
+Matt	 Evangelium nach Matthaus
+Matt	 Evangelium nach Matthäus
+Matt	Matthaeusevangelium
+Matt	Matthausevangelium
+Matt	Matthäusevangelium
+Matt	Matthaeus
 Matt	Matthaus
 Matt	Matthäus
 Matt	Matt
 Matt	Mt
+Mic	Michaeas
 Mic	Michaas
 Mic	Michäas
 Mic	Micha
+Mic	Mich
 Mic	Mic
 Mic	Mi
 Nah	Nahum
 Nah	Nah
 Neh	Nehemia
 Neh	Neh
+Num	Vierten Buch Mose
+Num	Viertes Buch Mose
 Num	Vierte Buch Mose
 Num	4. Buch Mose
+Num	Vierten Mose
+Num	Viertes Mose
 Num	4 Buch Mose
 Num	Vierte Mose
 Num	4. Mose
@@ -353,25 +577,31 @@ Num	4 Mos
 Num	4. Mo
 Num	4 Mo
 Num	Num
+Num	Nm
 Obad	Abdias
 Obad	Obadja
 Obad	Obad
 Obad	Obd
 Phil	Philipper
 Phil	Phil
-Phil,Phlm	Ph
 Phlm	Philemon
 Phlm	Phlm
 Phlm	Phm
+PrAzar	Das Gebet des Asarja
+PrAzar	Das Gebet Asarjas
 PrAzar	Gebet des Asarja
+PrAzar	Gebet Asarjas
 PrAzar	Geb As
 PrAzar	PrAzar
+PrMan	Das Gebet des Manasse
+PrMan	Das Gebet Manasses
 PrMan	Gebet des Manasse
 PrMan	Gebet Manasses
 PrMan	Gebet Manasse
 PrMan	Geb Man
 PrMan	Or Man
 PrMan	PrMan
+Prov	Sprichwoerter
 Prov	Sprichworter
 Prov	Sprichwörter
 Prov	Sprueche
@@ -381,6 +611,7 @@ Prov	Prov
 Prov	Spr
 Ps	Psalmen
 Ps	Psalm
+Ps	Pslm
 Ps	Ps
 Rev	Offenbarung
 Rev	Offb
@@ -388,34 +619,36 @@ Rev	Rev
 Rom	Roemer
 Rom	Romer
 Rom	Römer
+Rom	Roem
 Rom	Rom
 Rom	Röm
+Rom	Rm
 Ruth	Ruth
 Ruth	Rut
-SgThree	Lobgesang der drei jungen Manner im Feuerofen
-SgThree	Lobgesang der drei jungen Männer im Feuerofen
-SgThree	Der Gesang der Drei Manner im feurigen Ofen
-SgThree	Der Gesang der Drei Männer im feurigen Ofen
-SgThree	Lobgesang der drei jungen Manner
-SgThree	Lobgesang der drei jungen Männer
-SgThree	Lobgesang der 3 jungen Manner
-SgThree	Lobgesang der 3 jungen Männer
-SgThree	Der Gesang der Drei
+Ruth	Ru
+SgThree	Gesang der drei Maenner im Feuerofen
+SgThree	Gesang der drei Manner im Feuerofen
+SgThree	Gesang der drei Männer im Feuerofen
+SgThree	Gesang der drei im Feuerofen
+SgThree	Gesang der drei Maenner
+SgThree	Gesang der drei Manner
+SgThree	Gesang der drei Männer
 SgThree	Gesang der Drei
+SgThree	Gesang der drei
 SgThree	SgThree
 SgThree	L3J
 Sir	Ecclesiasticus
 Sir	Jesus Sirach
 Sir	Sir
+Song	Hoheslied Salomonis
 Song	Hohelied Salomonis
 Song	Hoheslied Salomos
+Song	Hohelied Salomos
 Song	Hohes Lied
 Song	Hoheslied
 Song	Hohelied
 Song	Song
 Song	Hld
-Sus	Susanna und die Alten
-Sus	Susanna im Bade
 Sus	Susanna
 Sus	Sus
 Titus	Titus
@@ -431,9 +664,7 @@ Zech	Zacharias
 Zech	Sacharja
 Zech	Sach
 Zech	Zech
-Zeph	Sophonias
 Zeph	Zephanja
 Zeph	Zefanja
-Zeph	Soph
 Zeph	Zeph
 Zeph	Zef

--- a/src/de/data.txt
+++ b/src/de/data.txt
@@ -1,84 +1,89 @@
-$FIRST	Erste	1
-$SECOND	Zweite	2
-$THIRD	Dritte	3
-$FOURTH	Vierte	4
-$FIFTH	Fünfte	5
+# Constants used below & in the parser
+$FIRST	Erste[nrs]?	1
+$SECOND	Zweite[nrs]?	2
+$THIRD	Dritte[nrs]?	3
+
+# Constants used only below (TODO: Implement $FOURTH & $FIFTH there, too)
+$FOURTH	Vierte[ns]?	4
+$FIFTH	Fünftes	5
+$GOSPEL	(Das)? Evangelium nach
+
+# Constants used only in the parser
 $AB	[a-e]
-$AND	und	vgl.
-$CHAPTER	Kapitel	Kap.
-$FF	ff
+$AND	und siehe auch	und siehe	und auch	sowie auch	siehe auch	siehe	sowie	u.	&	vgl.
+$CHAPTER	Kapiteln	Kapiteln	Kapitel	Kap.
+$FF	ff![a-z0-9äöü]
 $TITLE	Titel
 $TRANS	ELB	HFA	LUTHER	LUTH1545	SCH1950	SCH2000
 $TO	bis
-$VERSE	Verse	Vers.	Ver.	Vs.
+$VERSE	Versen	Verses	Verse	Vers.	Vers	Vs.
 $UNICODE_BLOCK	Latin
 
-# http://de.wikipedia.org/wiki/Bibel
-# http://de.wikipedia.org/wiki/Liste_biblischer_B%C3%BCcher
-Gen	$FIRST Mose	Genesis	$FIRST Buch Mose	1. Mos?	Gen
-Exod	$SECOND Mose	Exodus	$SECOND Buch Mose	2. Mos?	Ex
-Lev	$THIRD Mose	Levitikus	$THIRD Buch Mose	3. Mos?	Lev
-Num	$FOURTH Mose	Numeri	$FOURTH Buch Mose	4. Mos?	Num
-Deut	$FIFTH Mose	Deuteronomium	$FIFTH Buch Mose	5. Mos?	Dtn
+# Bible book abbreviations
+Gen	$FIRST Mose	$FIRST Buch Mose	1. Mos	1. Mo	Genesis	Gen	Gn
+Exod	$SECOND Mose	$SECOND Buch Mose	2. Mos	2. Mo	Exodus	Exod	Ex
+Lev	$THIRD Mose	$THIRD Buch Mose	3. Mos	3. Mo	Levitikus	Lev	Lv
+Num	$FOURTH Mose	$FOURTH Buch Mose	4. Mos	4. Mo	Numeri	Num	Nm
+Deut	$FIFTH Mose	$FIFTH Buch Mose	5. Mos	5. Mo	Deuteronomium	Deut	Dtn	Dt
 Josh	Josua	Jos
-Judg	Richter	Ri
-Ruth	Rut
-1Sam	$FIRST Samuel	1. Sam
-2Sam	$SECOND Samuel	2. Sam
-1Kgs	$FIRST Könige	$FIRST Koenige	1. Kön
-2Kgs	$SECOND Könige	$SECOND Koenige	2. Kön
-1Chr	$FIRST Chronik	1. Chr
-2Chr	$SECOND Chronik	2. Chr
+Judg	Richter	Rich	Ri
+Ruth	Rut	Ru
+1Sam	$FIRST Samuel	1. Sam	1. Sam	1. Sa
+2Sam	$SECOND Samuel	2. Sam	2. Sam	2. Sa
+1Kgs	$FIRST Könige	$FIRST Koenige	1. Kön	1. Koen	1. Kng	1. Kö	1. Koe
+2Kgs	$SECOND Könige	$SECOND Koenige	2. Kön	2. Koen	2. Kng	2. Kö	2. Koe
+1Chr	$FIRST Chronik	1. Chron	1. Chr
+2Chr	$SECOND Chronik	2. Chron	2. Chr
 Ezra	Esra	Esr
 Neh	Nehemia	Neh
-Esth	Esth?er	Est
+Esth	Esther	Ester	Est
 Job	Ijob	Hiob	Job	Hi
-Ps	Psalmen	Psalm	Ps
-Prov	Sprichwörter	Sprüche	Sprueche	Spr
+Ps	Psalmen	Psalm	Pslm	Ps
+Prov	Sprichwörter	Sprichwoerter	Sprüche	Sprueche	Spr
 Eccl	Prediger	Kohelet	Ekklesiastes	Ecclesiastes	Pred	Koh
-Song	Hoheslied	Hoheslied Salomos	Hohes Lied	Hohelied Salomonis	Hohelied	Hld
+Song	Hohes?lied Salomos	Hohes?lied Salomonis	Hohes?lied	Hohes Lied	Hld
 Isa	Jesaja	Isaias	Jes
 Jer	Jeremia	Jeremias	Jer
 Lam	Klagelieder Jeremias	Klagelieder	Klgl	Klag
-Ezek	Ezechiel	Hesekiel	Hes	Ez
+Ezek	Ezechiel	Hesekiel	Hesek	Hes	Ez
 Dan	Daniel	Dan
-Hos	Hosea	Osee	Hos
-Joel	Joel	Joel
+Hos	Hosea	Hos
+Joel	Joel
 Amos	Amos	Am
-Obad	Obadja	Abdias	Obd
-Jonah	Jona	Jonas
-Mic	Micha	Michäas	Mi
+Obad	Obadja	Abdias	Obad	Obd
+Jonah	Jonas	Jona
+Mic	Micha	Michäas	Michaeas	Mich	Mi
 Nah	Nahum	Nah
 Hab	Habakuk	Hab
-Zeph	Zefanja	Sophonias	Zephanja	Zef	Soph
-Hag	Haggai	Aggäus	Hag	Agg?
+Zeph	Zefanja	Zephanja	Zef
+Hag	Haggai	Hagg	Hag
 Zech	Sacharja	Zacharias	Sach
 Mal	Maleachi	Malachias	Mal
-Matt	Matthäus	Mt
-Mark	Markus	Mk
-Luke	Lukas	Lk
-John	Johannes	Joh
+Matt	$GOSPEL Matthäus	$GOSPEL Matthaeus	Matthäusevangelium	Matthaeusevangelium	Matthäus	Matthaeus	Matt	Mt
+Mark	$GOSPEL Markus	Markusevangelium	Markus	Mark	Mk
+Luke	$GOSPEL Lukas	Lukasevangelium	Lukas	Luk	Lk
+John	$GOSPEL Johannes	Johannesevangelium	Johannes	Joh
 Acts	Apostelgeschichte	Apg
-Rom	Römer	Roemer	Röm
+Rom	Römer	Roemer	Röm	Roem	Rm
 1Cor	$FIRST Korinther	1. Kor
 2Cor	$SECOND Korinther	2. Kor
 Gal	Galater	Gal
 Eph	Epheser	Eph
 Phil	Philipper	Phil
 Col	Kolosser	Kol
-1Thess	$FIRST Thessalonicher	1. Thess
-2Thess	$SECOND Thessalonicher	2. Thess
+1Thess	$FIRST Thessalonicher	1. Thess	1. Th
+2Thess	$SECOND Thessalonicher	2. Thess	2. Th
 1Tim	$FIRST Timotheus	1. Tim
 2Tim	$SECOND Timotheus	2. Tim
 Titus	Titus	Tit
 Phlm	Philemon	Phlm	Phm
-Heb	Hebräer	Hebraeer	Hebr
-Jas	Jakobusbrief	Jakobus	Jak
-1Pet	$FIRST Petrus	1. Petr
-2Pet	$SECOND Petrus	2. Petr
-1John	$FIRST Johannes	1. Joh
-2John	$SECOND Johannes	2. Joh
-3John	$THIRD Johannes	3. Joh
+Heb	Hebräer	Hebraeer	Hebr	Heb	Hb
+Jas	Jakobusbrief	Jakobus	Jk
+1Pet	$FIRST Petrus	1. Petr	1. Pet	1. Pt
+2Pet	$SECOND Petrus	2. Petr	2. Pet	2. Pt
+1John	$FIRST Johannes	1. Joh	1. Jo
+2John	$SECOND Johannes	2. Joh	2. Jo
+3John	$THIRD Johannes	3. Joh	3. Jo
 Jude	Judas	Jud
 Rev	Offenbarung	Offb
 Tob	Tobit	Tobias	Tob
@@ -87,22 +92,20 @@ GkEsth	Ester \(Griechisch\)	Gr Est
 Wis	Weisheit Salomos	Weisheit	Weish
 Sir	Jesus Sirach	Ecclesiasticus	Sir
 Bar	Baruch	Bar
-PrAzar	Gebet des Asarja	Geb As
-Sus	Susanna im Bade	Susanna und die Alten	Susanna	Sus
-Bel	Bel und Vom Drachen	Bel
-SgThree	Lobgesang der drei jungen Männer im Feuerofen	Lobgesang der drei jungen Männer	Lobgesang der 3 jungen Männer	Der Gesang der Drei Männer im feurigen Ofen	Gesang der Drei	Der Gesang der Drei	L3J
+PrAzar	(Das )?Gebet des Asarja	(Das )?Gebet Asarjas	Geb As
+Sus	Susanna	Sus
+Bel	Bel und (der? )Drache	Bel
+SgThree	Gesang der drei( Männer)?( im Feuerofen)?	Gesang der drei Maenner( im Feuerofen)?	L3J
 EpJer	Brief des Jeremia	Br Jer
-1Macc	$FIRST Makkabäer	1. Makk
-2Macc	$SECOND Makkabäer	2. Makk
-3Macc	$THIRD Makkabäer	3. Makk
-4Macc	$FOURTH Makkabäer	4. Makk
-1Esd	$FIRST Esra	1. Esr?
-2Esd	$SECOND Esra	2. Esr?
-PrMan	Gebet des Manasse	Gebet Manasses?	Geb Man	Or Man
-Phil,Phlm	Ph
-Ezra,Esth	Es
+1Macc	$FIRST Makkabäer	$FIRST Makkabaeer	1. Makk
+2Macc	$SECOND Makkabäer	$SECOND Makkabaeer	2. Makk
+3Macc	$THIRD Makkabäer	$THIRD Makkabaeer	3. Makk
+4Macc	$FOURTH Makkabäer	$FOURTH Makkabaeer	4. Makk
+1Esd	$FIRST Esd?ra	1. Esd?r	1. Es
+2Esd	$SECOND Esd?ra	2. Esd?r	2. Es
+PrMan	(Das )?Gebet des Manasse	(Das )?Gebet Manasses	Gebet Manasse	Geb Man	Or Man
 
-# Order
+# Parsing order
 =Gen
 =Exod
 =Bel

--- a/src/de/grammar.pegjs
+++ b/src/de/grammar.pegjs
@@ -107,7 +107,7 @@ c
 
 // No `b` or `ps151`.
 ff
-  = val_1:(bcv / bcv_weak / bc / bv / cv / cv_weak / integer / c / v) sp "ff" abbrev? ![a-z]
+  = val_1:(bcv / bcv_weak / bc / bv / cv / cv_weak / integer / c / v) sp "ff" ! [a-z0-9äaöoüu]i abbrev? ![a-z]
     { return {"type": "ff", "value": [val_1], "indices": [peg$savedPos, peg$currPos - 1]} }
 
 integer_title
@@ -132,7 +132,7 @@ ps151_bcv
     { return {"type": "bcv", "value": [val_1, {"type": "v", "value": [val_2], "indices": [val_2.indices[0], val_2.indices[1]]}], "indices": [peg$savedPos, peg$currPos - 1]} }
 
 v_letter
-  = v_explicit? val:integer sp !( "ff" ) [a-e] ![a-z]
+  = v_explicit? val:integer sp !( "ff" ! [a-z0-9äaöoüu]i ) [a-e] ![a-z]
     { return {"type": "v", "value": [val], "indices": [peg$savedPos, peg$currPos - 1]} }
 
 v
@@ -141,11 +141,11 @@ v
 
 /* BCV helpers */
 c_explicit
-  = sp ( "kap" ( "itel" / abbrev? ) ) sp
+  = sp ( "kap" ( "iteln" / "iteln" / "itel" / abbrev? ) ) sp
     { return {"type": "c_explicit"} }
 
 v_explicit
-  = sp ( "v" ( "erse" / "ers" abbrev? / "er" abbrev? / "s" abbrev? ) ) ![a-z] sp
+  = sp ( "v" ( "ersen" / "erses" / "erse" / "ers" abbrev? / "ers" / "s" abbrev? ) ) ![a-z] sp
     { return {"type": "v_explicit"} }
 
 cv_sep
@@ -156,7 +156,7 @@ cv_sep_weak
 
 /* The opening regexp is overwritten during post-processing to allow flexibility on including the comma. */
 sequence_sep
-  = ([,;/:&\-\u2013\u2014~] / "." !(sp "." sp ".") / "und" / "vgl" abbrev? / space)+
+  = ([,;/:&\-\u2013\u2014~] / "." !(sp "." sp ".") / "und" space "siehe" space "auch" / "und" space "siehe" / "und" space "auch" / "sowie" space "auch" / "siehe" space "auch" / "siehe" / "sowie" / "u" abbrev? / "&" / "vgl" abbrev? / space)+
     { return "" }
 
 range_sep

--- a/src/de/regexps.coffee
+++ b/src/de/regexps.coffee
@@ -19,7 +19,7 @@ bcv_parser::regexps.escaped_passage = ///
 				    /\d+\x1f				#special Psalm chapters
 				  | [\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014]
 				  | Titel (?! [a-z] )		#could be followed by a number
-				  | Kapitel | Verse | Vers | Kap | bis | und | vgl | Ver | ff | Vs
+				  | und#{bcv_parser::regexps.space}+siehe#{bcv_parser::regexps.space}+auch | sowie#{bcv_parser::regexps.space}+auch | siehe#{bcv_parser::regexps.space}+auch | und#{bcv_parser::regexps.space}+siehe | und#{bcv_parser::regexps.space}+auch | ff(?![a-z0-9äaöoüu]) | Kapiteln | Kapiteln | Kapitel | Versen | Verses | siehe | sowie | Verse | Vers | Vers | Kap | bis | vgl | Vs | u | &
 				  | [a-e] (?! \w )			#a-e allows 1:1a
 				  | $						#or the end of the string
 				 )+
@@ -28,7 +28,7 @@ bcv_parser::regexps.escaped_passage = ///
 # These are the only valid ways to end a potential passage match. The closing parenthesis allows for fully capturing parentheses surrounding translations (ESV**)**. The last one, `[\d\x1f]` needs not to be +; otherwise `Gen5ff` becomes `\x1f0\x1f5ff`, and `adjust_regexp_end` matches the `\x1f5` and incorrectly dangles the ff.
 bcv_parser::regexps.match_end_split = ///
 	  \d \W* Titel
-	| \d \W* ff (?: [\s\xa0*]* \.)?
+	| \d \W* ff(?![a-z0-9äaöoüu]) (?: [\s\xa0*]* \.)?
 	| \d [\s\xa0*]* [a-e] (?! \w )
 	| \x1e (?: [\s\xa0*]* [)\]\uff09] )? #ff09 is a full-width closing parenthesis
 	| [\d\x1f]
@@ -36,10 +36,10 @@ bcv_parser::regexps.match_end_split = ///
 bcv_parser::regexps.control = /[\x1e\x1f]/g
 bcv_parser::regexps.pre_book = "[^A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ]"
 
-bcv_parser::regexps.first = "(?:Erste|1)\\.?#{bcv_parser::regexps.space}*"
-bcv_parser::regexps.second = "(?:Zweite|2)\\.?#{bcv_parser::regexps.space}*"
-bcv_parser::regexps.third = "(?:Dritte|3)\\.?#{bcv_parser::regexps.space}*"
-bcv_parser::regexps.range_and = "(?:[&\u2013\u2014-]|(?:und|vgl)|bis)"
+bcv_parser::regexps.first = "(?:Erste[nrs]?|1)\\.?#{bcv_parser::regexps.space}*"
+bcv_parser::regexps.second = "(?:Zweite[nrs]?|2)\\.?#{bcv_parser::regexps.space}*"
+bcv_parser::regexps.third = "(?:Dritte[nrs]?|3)\\.?#{bcv_parser::regexps.space}*"
+bcv_parser::regexps.range_and = "(?:[&\u2013\u2014-]|(?:und#{bcv_parser::regexps.space}+siehe#{bcv_parser::regexps.space}+auch|und#{bcv_parser::regexps.space}+siehe|und#{bcv_parser::regexps.space}+auch|sowie#{bcv_parser::regexps.space}+auch|siehe#{bcv_parser::regexps.space}+auch|siehe|sowie|u|&|vgl)|bis)"
 bcv_parser::regexps.range_only = "(?:[\u2013\u2014-]|bis)"
 # Each book regexp should return two parenthesized objects: an optional preliminary character and the book itself.
 bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
@@ -54,34 +54,34 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Gen"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1\.?[\s\xa0]*Mose|Genesis)|(?:1\.?[\s\xa0]*Mos|Gen|1\.?[\s\xa0]*Mo|1\.?[\s\xa0]*Buch[\s\xa0]*Mose|Erste[\s\xa0]*(?:Buch[\s\xa0]*)?Mose)
+		(?:Erste(?:[nrs][\s\xa0]*(?:Buch[\s\xa0]*)?|[\s\xa0]*(?:Buch[\s\xa0]*)?)Mose|1\.?[\s\xa0]*Buch[\s\xa0]*Mose|G(?:enesis|n)|1\.?[\s\xa0]*Mose|1(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|Gen)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Exod"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2\.?[\s\xa0]*Mose|Exodus)|(?:2\.?[\s\xa0]*Mos|Exod|2\.?[\s\xa0]*Mo|Ex|2\.?[\s\xa0]*Buch[\s\xa0]*Mose|Zweite[\s\xa0]*(?:Buch[\s\xa0]*)?Mose)
+		(?:Zweite(?:[nrs][\s\xa0]*(?:Buch[\s\xa0]*)?|[\s\xa0]*(?:Buch[\s\xa0]*)?)Mose|2\.?[\s\xa0]*Buch[\s\xa0]*Mose|2\.?[\s\xa0]*Mose|2(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|Exodus|Ex(?:od)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Bel"]
 		apocrypha: true
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Bel(?:[\s\xa0]*und[\s\xa0]*Vom[\s\xa0]*Drachen)?)
+		(?:Bel(?:[\s\xa0]*und[\s\xa0]*(?:Vom[\s\xa0]*Drachen|der?[\s\xa0]*Drache))?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Lev"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:Levitikus|3\.?[\s\xa0]*Mose)|(?:3\.?[\s\xa0]*Mos|Lev|3\.?[\s\xa0]*Mo|3\.?[\s\xa0]*Buch[\s\xa0]*Mose|Dritte[\s\xa0]*(?:Buch[\s\xa0]*)?Mose)
+		(?:Dritte(?:[nrs][\s\xa0]*(?:Buch[\s\xa0]*)?|[\s\xa0]*(?:Buch[\s\xa0]*)?)Mose|3\.?[\s\xa0]*Buch[\s\xa0]*Mose|L(?:evitikus|v)|3\.?[\s\xa0]*Mose|3(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|Lev)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Num"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:4\.?[\s\xa0]*Mose|Numeri)|(?:4\.?[\s\xa0]*Mos|Num|4\.?[\s\xa0]*Mo|4\.?[\s\xa0]*Buch[\s\xa0]*Mose|Vierte[\s\xa0]*(?:Buch[\s\xa0]*)?Mose)
+		(?:Vierte(?:[ns][\s\xa0]*(?:Buch[\s\xa0]*)?|[\s\xa0]*(?:Buch[\s\xa0]*)?)Mose|4\.?[\s\xa0]*Buch[\s\xa0]*Mose|4\.?[\s\xa0]*Mose|4(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|N(?:umeri|m)|Num)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Sir"]
 		apocrypha: true
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Jesus[\s\xa0]*Sirach|Sir|Ecclesiasticus)
+		(?:Ecclesiasticus|Jesus[\s\xa0]*Sirach|Sir)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Wis"]
@@ -109,12 +109,12 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 		osis: ["PrMan"]
 		apocrypha: true
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Geb(?:et[\s\xa0]*(?:des[\s\xa0]*Manasse|Manasses?)|[\s\xa0]*Man)|(?:Or[\s\xa0]*|Pr)Man)
+		(?:Das[\s\xa0]*Gebet[\s\xa0]*(?:des[\s\xa0]*Manasse|Manasses)|Gebet[\s\xa0]*des[\s\xa0]*Manasse|Geb(?:et[\s\xa0]*Manasses|[\s\xa0]*Man)|Gebet[\s\xa0]*Manasse|(?:Or[\s\xa0]*|Pr)Man)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Deut"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:D(?:euteronomium|tn)|5\.?[\s\xa0]*Mose|5(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|Deut|5\.?[\s\xa0]*Buch[\s\xa0]*Mose|F[u\xFC]nfte[\s\xa0]*(?:Buch[\s\xa0]*)?Mose)
+		(?:F[u\xFC]nftes[\s\xa0]*(?:Buch[\s\xa0]*)?Mose|D(?:euteronomium|tn)|5\.?[\s\xa0]*Buch[\s\xa0]*Mose|5\.?[\s\xa0]*Mose|5(?:\.[\s\xa0]*Mos?|[\s\xa0]*Mos?)|D(?:eu)?t)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Josh"]
@@ -124,64 +124,64 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Judg"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ri(?:chter)?|Judg)
+		(?:Ri(?:ch(?:ter)?)?|Judg)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Ruth"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ruth?)
+		(?:Ru(?:th?)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1Esd"]
 		apocrypha: true
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1(?:[\s\xa0]*Esra|Esd|\.[\s\xa0]*Esra|\.[\s\xa0]*Esr?|[\s\xa0]*Esr?)|Erste[\s\xa0]*Esra)
+		(?:1Esd)|(?:Erste(?:[nrs][\s\xa0]*Esd?|[\s\xa0]*Esd?)ra|1(?:(?:\.[\s\xa0]*Esd?|[\s\xa0]*Esd?)ra|\.[\s\xa0]*Es(?:dr|r)?|[\s\xa0]*Es(?:dr|r)?))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["2Esd"]
 		apocrypha: true
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2(?:[\s\xa0]*Esra|Esd|\.[\s\xa0]*Esra|\.[\s\xa0]*Esr?|[\s\xa0]*Esr?)|Zweite[\s\xa0]*Esra)
+		(?:2Esd)|(?:Zweite(?:[nrs][\s\xa0]*Esd?|[\s\xa0]*Esd?)ra|2(?:(?:\.[\s\xa0]*Esd?|[\s\xa0]*Esd?)ra|\.[\s\xa0]*Es(?:dr|r)?|[\s\xa0]*Es(?:dr|r)?))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Isa"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Isa(?:ias)?|Jes(?:aja)?)
+		(?:Jes(?:aja)?|Isa(?:ias)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["2Sam"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2\.?[\s\xa0]*Samuel)|(?:2(?:\.[\s\xa0]*|[\s\xa0]*)?Sam|Zweite[\s\xa0]*Samuel)
+		(?:Zweite[nrs]?[\s\xa0]*Samuel|2(?:\.?[\s\xa0]*Samuel|\.[\s\xa0]*Sam?|[\s\xa0]*Sam?|Sam))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1Sam"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1\.?[\s\xa0]*Samuel)|(?:1(?:\.[\s\xa0]*|[\s\xa0]*)?Sam|Erste[\s\xa0]*Samuel)
+		(?:Erste[nrs]?[\s\xa0]*Samuel|1(?:\.?[\s\xa0]*Samuel|\.[\s\xa0]*Sam?|[\s\xa0]*Sam?|Sam))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["2Kgs"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2(?:\.[\s\xa0]*K[o\xF6]|[\s\xa0]*K[o\xF6])nige)|(?:2(?:[\s\xa0]*K[o\xF6]n|Kgs|\.[\s\xa0]*K[o\xF6]n|\.?[\s\xa0]*Koenige)|Zweite[\s\xa0]*K(?:\xF6|oe?)nige)
+		(?:Zweite(?:[nrs][\s\xa0]*K(?:oe?|\xF6)|[\s\xa0]*K(?:oe?|\xF6))nige|2(?:(?:\.[\s\xa0]*K(?:oe?|\xF6)|[\s\xa0]*K(?:oe?|\xF6))nige|\.[\s\xa0]*K(?:o(?:en?|n)?|\xF6n?)|[\s\xa0]*K(?:o(?:en?|n)?|\xF6n?)|\.[\s\xa0]*Kng|[\s\xa0]*Kng|Kgs))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1Kgs"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1(?:\.[\s\xa0]*K[o\xF6]|[\s\xa0]*K[o\xF6])nige)|(?:1(?:[\s\xa0]*K[o\xF6]n|Kgs|\.[\s\xa0]*K[o\xF6]n|\.?[\s\xa0]*Koenige)|Erste[\s\xa0]*K(?:\xF6|oe?)nige)
+		(?:Erste(?:[nrs][\s\xa0]*K(?:oe?|\xF6)|[\s\xa0]*K(?:oe?|\xF6))nige|1(?:(?:\.[\s\xa0]*K(?:oe?|\xF6)|[\s\xa0]*K(?:oe?|\xF6))nige|\.[\s\xa0]*K(?:o(?:en?|n)?|\xF6n?)|[\s\xa0]*K(?:o(?:en?|n)?|\xF6n?)|\.[\s\xa0]*Kng|[\s\xa0]*Kng|Kgs))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["2Chr"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2\.?[\s\xa0]*Chronik)|(?:Zweite[\s\xa0]*Chronik|2(?:\.[\s\xa0]*|[\s\xa0]*)?Chr)
+		(?:Zweite[nrs]?[\s\xa0]*Chronik|2(?:\.?[\s\xa0]*Chronik|\.[\s\xa0]*Chr(?:on)?|[\s\xa0]*Chr(?:on)?|Chr))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1Chr"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1\.?[\s\xa0]*Chronik)|(?:1(?:\.[\s\xa0]*|[\s\xa0]*)?Chr|Erste[\s\xa0]*Chronik)
+		(?:Erste[nrs]?[\s\xa0]*Chronik|1(?:\.?[\s\xa0]*Chronik|\.[\s\xa0]*Chr(?:on)?|[\s\xa0]*Chr(?:on)?|Chr))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Ezra"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:E(?:sra?|zra))
+		(?:E(?:zra|sra?))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Neh"]
@@ -192,7 +192,7 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 		osis: ["GkEsth"]
 		apocrypha: true
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ester[\s\xa0]*\(Griechisch\)|G(?:kEsth|r[\s\xa0]*Est))
+		(?:Ester[\s\xa0]*\(Griechisch\)|G(?:r[\s\xa0]*Est|kEsth))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Esth"]
@@ -207,34 +207,34 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Ps"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ps(?:alm(?:en)?)?)
+		(?:Ps(?:alm(?:en)?|lm)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["PrAzar"]
 		apocrypha: true
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Geb(?:et[\s\xa0]*des[\s\xa0]*Asarja|[\s\xa0]*As)|PrAzar)
+		(?:Das[\s\xa0]*Gebet[\s\xa0]*(?:des[\s\xa0]*Asarja|Asarjas)|Gebet[\s\xa0]*(?:des[\s\xa0]*Asarja|Asarjas)|PrAzar|Geb[\s\xa0]*As)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Prov"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Spr(?:(?:\xFC|ue?)che|ichw[o\xF6]rter)?|Prov)
+		(?:Spr(?:ichw(?:oe?|\xF6)rter|(?:ue?|\xFC)che)?|Prov)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Eccl"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:E(?:ccl(?:esiastes)?|kklesiastes)|Prediger|Kohelet|Pred|Koh)
+		(?:E(?:kklesiastes|ccl(?:esiastes)?)|Prediger|Kohelet|Pred|Koh)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["SgThree"]
 		apocrypha: true
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:Der[\s\xa0]*Gesang[\s\xa0]*der[\s\xa0]*Drei[\s\xa0]*M[a\xE4]nner[\s\xa0]*im[\s\xa0]*feurigen[\s\xa0]*Ofen|Gesang[\s\xa0]*der[\s\xa0]*Drei|SgThree|Der[\s\xa0]*Gesang[\s\xa0]*der[\s\xa0]*Drei|L(?:obgesang[\s\xa0]*der[\s\xa0]*(?:drei[\s\xa0]*jungen[\s\xa0]*M[a\xE4]nner(?:[\s\xa0]*im[\s\xa0]*Feuerofen)?|3[\s\xa0]*jungen[\s\xa0]*M[a\xE4]nner)|3J))
+		(?:Gesang[\s\xa0]*der[\s\xa0]*(?:drei(?:[\s\xa0]*(?:M(?:a(?:enner(?:[\s\xa0]*im[\s\xa0]*Feuerofen)?|nner(?:[\s\xa0]*im[\s\xa0]*Feuerofen)?)|\xE4nner(?:[\s\xa0]*im[\s\xa0]*Feuerofen)?)|im[\s\xa0]*Feuerofen))?|Drei)|SgThree|L3J)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Song"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:H(?:ohe(?:s(?:lied[\s\xa0]*Salomos|(?:[\s\xa0]*L|l)ied)|lied(?:[\s\xa0]*Salomonis)?)|ld)|Song)
+		(?:H(?:ohe(?:s(?:lied(?:[\s\xa0]*Salomo(?:ni)?s)?|[\s\xa0]*Lied)|lied(?:[\s\xa0]*Salomo(?:ni)?s)?)|ld)|Song)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Jer"]
@@ -244,7 +244,7 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Ezek"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ez(?:e(?:chiel|k))?|Hes(?:ekiel)?)
+		(?:Hes(?:ekiel|ek)?|Ez(?:e(?:chiel|k))?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Dan"]
@@ -254,7 +254,7 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Hos"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Hos(?:ea)?|Osee)
+		(?:Hos(?:ea)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Joel"]
@@ -269,7 +269,7 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Obad"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ob(?:adja|d|ad)|Abdias)
+		(?:Ob(?:adja|ad|d)|Abdias)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Jonah"]
@@ -279,7 +279,7 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Mic"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Mi(?:c(?:h(?:a(?:as)?|\xE4as))?)?)
+		(?:Mi(?:c(?:h(?:a(?:eas|as)?|\xE4as)?)?)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Nah"]
@@ -294,12 +294,12 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Zeph"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ze(?:(?:ph|f)anja|ph|f)|Soph(?:onias)?)
+		(?:Ze(?:ph(?:anja)?|f(?:anja)?))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Hag"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ag(?:g(?:[a\xE4]us)?)?|Hag(?:gai)?)
+		(?:Hag(?:g(?:ai)?)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Zech"]
@@ -314,37 +314,37 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Matt"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:M(?:att(?:h[a\xE4]us)?|t))
+		(?:Das[\s\xa0]*Evangelium[\s\xa0]*nach[\s\xa0]*Matth(?:ae?|\xE4)us|[\s\xa0]*Evangelium[\s\xa0]*nach[\s\xa0]*Matth(?:ae?|\xE4)us|M(?:atth(?:ae?|\xE4)usevangelium|att(?:h(?:ae?|\xE4)us)?|t))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Mark"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:M(?:ark(?:us)?|k))
+		(?:Das[\s\xa0]*Evangelium[\s\xa0]*nach[\s\xa0]*Markus|[\s\xa0]*Evangelium[\s\xa0]*nach[\s\xa0]*Markus|M(?:arkusevangelium|ark(?:us)?|k))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Luke"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:L(?:uk(?:as|e)|k))
+		(?:Das[\s\xa0]*Evangelium[\s\xa0]*nach[\s\xa0]*Lukas|[\s\xa0]*Evangelium[\s\xa0]*nach[\s\xa0]*Lukas|L(?:uk(?:asevangelium|e)|uk(?:as)?|k))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1John"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1John)|(?:1(?:\.?[\s\xa0]*Johannes|\.?[\s\xa0]*Joh)|Erste[\s\xa0]*Johannes)
+		(?:1John)|(?:Erste[nrs]?[\s\xa0]*Johannes|1(?:\.?[\s\xa0]*Johannes|\.[\s\xa0]*Joh?|[\s\xa0]*Joh?))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["2John"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2John)|(?:2(?:\.?[\s\xa0]*Johannes|\.?[\s\xa0]*Joh)|Zweite[\s\xa0]*Johannes)
+		(?:2John)|(?:Zweite[nrs]?[\s\xa0]*Johannes|2(?:\.?[\s\xa0]*Johannes|\.[\s\xa0]*Joh?|[\s\xa0]*Joh?))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["3John"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:3John)|(?:3(?:\.?[\s\xa0]*Johannes|\.?[\s\xa0]*Joh)|Dritte[\s\xa0]*Johannes)
+		(?:3John)|(?:Dritte[nrs]?[\s\xa0]*Johannes|3(?:\.?[\s\xa0]*Johannes|\.[\s\xa0]*Joh?|[\s\xa0]*Joh?))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["John"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Joh(?:annes|n)?)
+		(?:Das[\s\xa0]*Evangelium[\s\xa0]*nach[\s\xa0]*Johannes|[\s\xa0]*Evangelium[\s\xa0]*nach[\s\xa0]*Johannes|Joh(?:annesevangelium|annes|n)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Acts"]
@@ -354,17 +354,17 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Rom"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:R(?:o(?:m(?:er)?|emer)|\xF6m(?:er)?))
+		(?:R(?:o(?:em(?:er)?|m(?:er)?)|\xF6m(?:er)?|m))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["2Cor"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2\.?[\s\xa0]*Korinther)|(?:(?:Zweite[\s\xa0]*Korinthe|2(?:[\s\xa0]*K|C|\.[\s\xa0]*K)o)r)
+		(?:(?:Zweite[nrs]?[\s\xa0]*Korinthe|2(?:\.?[\s\xa0]*Korinthe|(?:\.?[\s\xa0]*K|C)o))r)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1Cor"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1\.?[\s\xa0]*Korinther)|(?:(?:1(?:[\s\xa0]*K|C|\.[\s\xa0]*K)o|Erste[\s\xa0]*Korinthe)r)
+		(?:(?:Erste[nrs]?[\s\xa0]*Korinthe|1(?:\.?[\s\xa0]*Korinthe|(?:\.?[\s\xa0]*K|C)o))r)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Gal"]
@@ -389,22 +389,22 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["2Thess"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2(?:\.?[\s\xa0]*Thessalonicher|(?:\.?[\s\xa0]*)?Thess)|Zweite[\s\xa0]*Thessalonicher)
+		(?:Zweite[nrs]?[\s\xa0]*Thessalonicher|2(?:\.?[\s\xa0]*Thessalonicher|\.[\s\xa0]*Th(?:ess)?|[\s\xa0]*Th(?:ess)?|Thess))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1Thess"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1(?:\.?[\s\xa0]*Thessalonicher|(?:\.?[\s\xa0]*)?Thess)|Erste[\s\xa0]*Thessalonicher)
+		(?:Erste[nrs]?[\s\xa0]*Thessalonicher|1(?:\.?[\s\xa0]*Thessalonicher|\.[\s\xa0]*Th(?:ess)?|[\s\xa0]*Th(?:ess)?|Thess))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["2Tim"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2(?:\.?[\s\xa0]*Timotheus|(?:\.?[\s\xa0]*)?Tim)|Zweite[\s\xa0]*Timotheus)
+		(?:Zweite[nrs]?[\s\xa0]*Timotheus|2(?:\.?[\s\xa0]*Timotheus|(?:\.?[\s\xa0]*)?Tim))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1Tim"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1(?:\.?[\s\xa0]*Timotheus|(?:\.?[\s\xa0]*)?Tim)|Erste[\s\xa0]*Timotheus)
+		(?:Erste[nrs]?[\s\xa0]*Timotheus|1(?:\.?[\s\xa0]*Timotheus|(?:\.?[\s\xa0]*)?Tim))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Titus"]
@@ -419,22 +419,22 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Heb"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Heb(?:r(?:\xE4er|aee?r)?)?)
+		(?:H(?:eb(?:r(?:aee?r|\xE4er)?)?|b))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Jas"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ja(?:k(?:obus(?:brief)?)?|s))
+		(?:J(?:a(?:k(?:obus(?:brief)?)?|s)|k))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["2Pet"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2\.?[\s\xa0]*Petrus)|(?:2(?:[\s\xa0]*Petr|Pet|\.[\s\xa0]*Petr)|Zweite[\s\xa0]*Petrus)
+		(?:Zweite[nrs]?[\s\xa0]*Petrus|2(?:\.?[\s\xa0]*Petrus|\.[\s\xa0]*Petr?|[\s\xa0]*Petr?|(?:\.[\s\xa0]*P|Pe|[\s\xa0]*P)t))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1Pet"]
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1\.?[\s\xa0]*Petrus)|(?:1(?:[\s\xa0]*Petr|Pet|\.[\s\xa0]*Petr)|Erste[\s\xa0]*Petrus)
+		(?:Erste[nrs]?[\s\xa0]*Petrus|1(?:\.?[\s\xa0]*Petrus|\.[\s\xa0]*Petr?|[\s\xa0]*Petr?|(?:\.[\s\xa0]*P|Pe|[\s\xa0]*P)t))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Jude"]
@@ -463,41 +463,31 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 		osis: ["Sus"]
 		apocrypha: true
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Sus(?:anna(?:[\s\xa0]*(?:und[\s\xa0]*die[\s\xa0]*Alten|im[\s\xa0]*Bade))?)?)
+		(?:Sus(?:anna)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["2Macc"]
 		apocrypha: true
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:2(?:\.?[\s\xa0]*Makkab[a\xE4]er|\.?[\s\xa0]*Makk|Macc)|Zweite[\s\xa0]*Makkab[a\xE4]er)
+		(?:Zweite(?:[nrs][\s\xa0]*Makkab(?:aee?|\xE4e)|[\s\xa0]*Makkab(?:aee?|\xE4e))r|2(?:\.?[\s\xa0]*Makkab(?:aee?|\xE4e)r|\.?[\s\xa0]*Makk|Macc))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["3Macc"]
 		apocrypha: true
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:3(?:\.?[\s\xa0]*Makkab[a\xE4]er|\.?[\s\xa0]*Makk|Macc)|Dritte[\s\xa0]*Makkab[a\xE4]er)
+		(?:Dritte(?:[nrs][\s\xa0]*Makkab(?:aee?|\xE4e)|[\s\xa0]*Makkab(?:aee?|\xE4e))r|3(?:\.?[\s\xa0]*Makkab(?:aee?|\xE4e)r|\.?[\s\xa0]*Makk|Macc))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["4Macc"]
 		apocrypha: true
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:4(?:\.?[\s\xa0]*Makkab[a\xE4]er|\.?[\s\xa0]*Makk|Macc)|Vierte[\s\xa0]*Makkab[a\xE4]er)
+		(?:Vierte(?:[ns][\s\xa0]*Makkab(?:aee?|\xE4e)|[\s\xa0]*Makkab(?:aee?|\xE4e))r|4(?:\.?[\s\xa0]*Makkab(?:aee?|\xE4e)r|\.?[\s\xa0]*Makk|Macc))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["1Macc"]
 		apocrypha: true
 		regexp: ///(^|[^0-9A-Za-zªµºÀ-ÖØ-öø-ɏḀ-ỿⱠ-ⱿꜢ-ꞈꞋ-ꞎꞐ-ꞓꞠ-Ɦꟸ-ꟿ])(
-		(?:1(?:\.?[\s\xa0]*Makkab[a\xE4]er|\.?[\s\xa0]*Makk|Macc)|Erste[\s\xa0]*Makkab[a\xE4]er)
-			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
-	,
-		osis: ["Ezra", "Esth"]
-		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Es)
-			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
-	,
-		osis: ["Phil", "Phlm"]
-		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ph)
+		(?:Erste(?:[nrs][\s\xa0]*Makkab(?:aee?|\xE4e)|[\s\xa0]*Makkab(?:aee?|\xE4e))r|1(?:\.?[\s\xa0]*Makkab(?:aee?|\xE4e)r|\.?[\s\xa0]*Makk|Macc))
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	]
 	# Short-circuit the look if we know we want all the books.

--- a/src/de/spec.coffee
+++ b/src/de/spec.coffee
@@ -52,9 +52,13 @@ describe "Localized book Gen (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Gen (de)", ->
 		`
+		expect(p.parse("Ersten Buch Mose 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("Erstes Buch Mose 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("Erste Buch Mose 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("1. Buch Mose 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("1 Buch Mose 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("Ersten Mose 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("Erstes Mose 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("Erste Mose 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("1. Mose 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("Genesis 1:1").osis()).toEqual("Gen.1.1")
@@ -65,9 +69,13 @@ describe "Localized book Gen (de)", ->
 		expect(p.parse("1 Mo 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("Gen 1:1").osis()).toEqual("Gen.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ERSTEN BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("ERSTES BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("ERSTE BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("1. BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("1 BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("ERSTEN MOSE 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("ERSTES MOSE 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("ERSTE MOSE 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("1. MOSE 1:1").osis()).toEqual("Gen.1.1")
 		expect(p.parse("GENESIS 1:1").osis()).toEqual("Gen.1.1")
@@ -87,8 +95,12 @@ describe "Localized book Exod (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Exod (de)", ->
 		`
+		expect(p.parse("Zweiten Buch Mose 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("Zweites Buch Mose 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("Zweite Buch Mose 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("2. Buch Mose 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("Zweiten Mose 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("Zweites Mose 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("2 Buch Mose 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("Zweite Mose 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("2. Mose 1:1").osis()).toEqual("Exod.1.1")
@@ -101,8 +113,12 @@ describe "Localized book Exod (de)", ->
 		expect(p.parse("Exod 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("Ex 1:1").osis()).toEqual("Exod.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ZWEITEN BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("ZWEITES BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("ZWEITE BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("2. BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("ZWEITEN MOSE 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("ZWEITES MOSE 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("2 BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("ZWEITE MOSE 1:1").osis()).toEqual("Exod.1.1")
 		expect(p.parse("2. MOSE 1:1").osis()).toEqual("Exod.1.1")
@@ -136,8 +152,12 @@ describe "Localized book Lev (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Lev (de)", ->
 		`
+		expect(p.parse("Dritten Buch Mose 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("Drittes Buch Mose 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("Dritte Buch Mose 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("3. Buch Mose 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("Dritten Mose 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("Drittes Mose 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("3 Buch Mose 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("Dritte Mose 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("Levitikus 1:1").osis()).toEqual("Lev.1.1")
@@ -149,8 +169,12 @@ describe "Localized book Lev (de)", ->
 		expect(p.parse("3 Mo 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("Lev 1:1").osis()).toEqual("Lev.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("DRITTEN BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("DRITTES BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("DRITTE BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("3. BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("DRITTEN MOSE 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("DRITTES MOSE 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("3 BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("DRITTE MOSE 1:1").osis()).toEqual("Lev.1.1")
 		expect(p.parse("LEVITIKUS 1:1").osis()).toEqual("Lev.1.1")
@@ -171,8 +195,12 @@ describe "Localized book Num (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Num (de)", ->
 		`
+		expect(p.parse("Vierten Buch Mose 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("Viertes Buch Mose 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("Vierte Buch Mose 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("4. Buch Mose 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("Vierten Mose 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("Viertes Mose 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("4 Buch Mose 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("Vierte Mose 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("4. Mose 1:1").osis()).toEqual("Num.1.1")
@@ -184,8 +212,12 @@ describe "Localized book Num (de)", ->
 		expect(p.parse("4 Mo 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("Num 1:1").osis()).toEqual("Num.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("VIERTEN BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("VIERTES BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("VIERTE BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("4. BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("VIERTEN MOSE 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("VIERTES MOSE 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("4 BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("VIERTE MOSE 1:1").osis()).toEqual("Num.1.1")
 		expect(p.parse("4. MOSE 1:1").osis()).toEqual("Num.1.1")
@@ -300,12 +332,14 @@ describe "Localized book Deut (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Deut (de)", ->
 		`
-		expect(p.parse("Funfte Buch Mose 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("Fünften Buch Mose 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("Fünftes Buch Mose 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("Fünfte Buch Mose 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("Deuteronomium 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("5. Buch Mose 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("Fünften Mose 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("Fünftes Mose 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("5 Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Funfte Mose 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("Fünfte Mose 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("5. Mose 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("5 Mose 1:1").osis()).toEqual("Deut.1.1")
@@ -316,12 +350,14 @@ describe "Localized book Deut (de)", ->
 		expect(p.parse("Deut 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("Dtn 1:1").osis()).toEqual("Deut.1.1")
 		p.include_apocrypha(false)
-		expect(p.parse("FUNFTE BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("FÜNFTEN BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("FÜNFTES BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("FÜNFTE BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("DEUTERONOMIUM 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("5. BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("FÜNFTEN MOSE 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("FÜNFTES MOSE 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("5 BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("FUNFTE MOSE 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("FÜNFTE MOSE 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("5. MOSE 1:1").osis()).toEqual("Deut.1.1")
 		expect(p.parse("5 MOSE 1:1").osis()).toEqual("Deut.1.1")
@@ -390,6 +426,8 @@ describe "Localized book 1Esd (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Esd (de)", ->
 		`
+		expect(p.parse("Ersten Esra 1:1").osis()).toEqual("1Esd.1.1")
+		expect(p.parse("Erstes Esra 1:1").osis()).toEqual("1Esd.1.1")
 		expect(p.parse("Erste Esra 1:1").osis()).toEqual("1Esd.1.1")
 		expect(p.parse("1. Esra 1:1").osis()).toEqual("1Esd.1.1")
 		expect(p.parse("1 Esra 1:1").osis()).toEqual("1Esd.1.1")
@@ -408,6 +446,8 @@ describe "Localized book 2Esd (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Esd (de)", ->
 		`
+		expect(p.parse("Zweiten Esra 1:1").osis()).toEqual("2Esd.1.1")
+		expect(p.parse("Zweites Esra 1:1").osis()).toEqual("2Esd.1.1")
 		expect(p.parse("Zweite Esra 1:1").osis()).toEqual("2Esd.1.1")
 		expect(p.parse("2. Esra 1:1").osis()).toEqual("2Esd.1.1")
 		expect(p.parse("2 Esra 1:1").osis()).toEqual("2Esd.1.1")
@@ -445,6 +485,8 @@ describe "Localized book 2Sam (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Sam (de)", ->
 		`
+		expect(p.parse("Zweiten Samuel 1:1").osis()).toEqual("2Sam.1.1")
+		expect(p.parse("Zweites Samuel 1:1").osis()).toEqual("2Sam.1.1")
 		expect(p.parse("Zweite Samuel 1:1").osis()).toEqual("2Sam.1.1")
 		expect(p.parse("2. Samuel 1:1").osis()).toEqual("2Sam.1.1")
 		expect(p.parse("2 Samuel 1:1").osis()).toEqual("2Sam.1.1")
@@ -452,6 +494,8 @@ describe "Localized book 2Sam (de)", ->
 		expect(p.parse("2 Sam 1:1").osis()).toEqual("2Sam.1.1")
 		expect(p.parse("2Sam 1:1").osis()).toEqual("2Sam.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ZWEITEN SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
+		expect(p.parse("ZWEITES SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
 		expect(p.parse("ZWEITE SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
 		expect(p.parse("2. SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
 		expect(p.parse("2 SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
@@ -468,6 +512,8 @@ describe "Localized book 1Sam (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Sam (de)", ->
 		`
+		expect(p.parse("Ersten Samuel 1:1").osis()).toEqual("1Sam.1.1")
+		expect(p.parse("Erstes Samuel 1:1").osis()).toEqual("1Sam.1.1")
 		expect(p.parse("Erste Samuel 1:1").osis()).toEqual("1Sam.1.1")
 		expect(p.parse("1. Samuel 1:1").osis()).toEqual("1Sam.1.1")
 		expect(p.parse("1 Samuel 1:1").osis()).toEqual("1Sam.1.1")
@@ -475,6 +521,8 @@ describe "Localized book 1Sam (de)", ->
 		expect(p.parse("1 Sam 1:1").osis()).toEqual("1Sam.1.1")
 		expect(p.parse("1Sam 1:1").osis()).toEqual("1Sam.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ERSTEN SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
+		expect(p.parse("ERSTES SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
 		expect(p.parse("ERSTE SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
 		expect(p.parse("1. SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
 		expect(p.parse("1 SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
@@ -491,14 +539,12 @@ describe "Localized book 2Kgs (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Kgs (de)", ->
 		`
-		expect(p.parse("Zweite Koenige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("Zweite Konige 1:1").osis()).toEqual("2Kgs.1.1")
+		expect(p.parse("Zweiten Könige 1:1").osis()).toEqual("2Kgs.1.1")
+		expect(p.parse("Zweites Könige 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("Zweite Könige 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2. Koenige 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2 Koenige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Konige 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2. Könige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Konige 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2 Könige 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2. Kon 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2. Kön 1:1").osis()).toEqual("2Kgs.1.1")
@@ -506,14 +552,15 @@ describe "Localized book 2Kgs (de)", ->
 		expect(p.parse("2 Kön 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2Kgs 1:1").osis()).toEqual("2Kgs.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ZWEITEN KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
+		expect(p.parse("ZWEITES KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("ZWEITE KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("ZWEITE KONIGE 1:1").osis()).toEqual("2Kgs.1.1")
+		expect(p.parse("ZWEITEN KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
+		expect(p.parse("ZWEITES KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("ZWEITE KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2. KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2 KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KONIGE 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2. KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KONIGE 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2 KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2. KON 1:1").osis()).toEqual("2Kgs.1.1")
 		expect(p.parse("2. KÖN 1:1").osis()).toEqual("2Kgs.1.1")
@@ -530,29 +577,30 @@ describe "Localized book 1Kgs (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Kgs (de)", ->
 		`
+		expect(p.parse("Ersten Koenige 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("Erstes Koenige 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("Erste Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("Erste Konige 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("Ersten Könige 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("Erstes Könige 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("Erste Könige 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1. Koenige 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1 Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Konige 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1. Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Konige 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1 Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Kon 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1. Kön 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1 Kon 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1 Kön 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1Kgs 1:1").osis()).toEqual("1Kgs.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ERSTEN KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("ERSTES KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("ERSTE KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("ERSTE KONIGE 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("ERSTEN KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("ERSTES KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("ERSTE KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1. KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1 KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KONIGE 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1. KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KONIGE 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1 KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1. KON 1:1").osis()).toEqual("1Kgs.1.1")
 		expect(p.parse("1. KÖN 1:1").osis()).toEqual("1Kgs.1.1")
@@ -569,6 +617,8 @@ describe "Localized book 2Chr (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Chr (de)", ->
 		`
+		expect(p.parse("Zweiten Chronik 1:1").osis()).toEqual("2Chr.1.1")
+		expect(p.parse("Zweites Chronik 1:1").osis()).toEqual("2Chr.1.1")
 		expect(p.parse("Zweite Chronik 1:1").osis()).toEqual("2Chr.1.1")
 		expect(p.parse("2. Chronik 1:1").osis()).toEqual("2Chr.1.1")
 		expect(p.parse("2 Chronik 1:1").osis()).toEqual("2Chr.1.1")
@@ -576,6 +626,8 @@ describe "Localized book 2Chr (de)", ->
 		expect(p.parse("2 Chr 1:1").osis()).toEqual("2Chr.1.1")
 		expect(p.parse("2Chr 1:1").osis()).toEqual("2Chr.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ZWEITEN CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
+		expect(p.parse("ZWEITES CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
 		expect(p.parse("ZWEITE CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
 		expect(p.parse("2. CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
 		expect(p.parse("2 CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
@@ -592,6 +644,8 @@ describe "Localized book 1Chr (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Chr (de)", ->
 		`
+		expect(p.parse("Ersten Chronik 1:1").osis()).toEqual("1Chr.1.1")
+		expect(p.parse("Erstes Chronik 1:1").osis()).toEqual("1Chr.1.1")
 		expect(p.parse("Erste Chronik 1:1").osis()).toEqual("1Chr.1.1")
 		expect(p.parse("1. Chronik 1:1").osis()).toEqual("1Chr.1.1")
 		expect(p.parse("1 Chronik 1:1").osis()).toEqual("1Chr.1.1")
@@ -599,6 +653,8 @@ describe "Localized book 1Chr (de)", ->
 		expect(p.parse("1 Chr 1:1").osis()).toEqual("1Chr.1.1")
 		expect(p.parse("1Chr 1:1").osis()).toEqual("1Chr.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ERSTEN CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
+		expect(p.parse("ERSTES CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
 		expect(p.parse("ERSTE CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
 		expect(p.parse("1. CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
 		expect(p.parse("1 CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
@@ -729,18 +785,16 @@ describe "Localized book Prov (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Prov (de)", ->
 		`
-		expect(p.parse("Sprichworter 1:1").osis()).toEqual("Prov.1.1")
+		expect(p.parse("Sprichwoerter 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("Sprichwörter 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("Sprueche 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Spruche 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("Sprüche 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("Prov 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("Spr 1:1").osis()).toEqual("Prov.1.1")
 		p.include_apocrypha(false)
-		expect(p.parse("SPRICHWORTER 1:1").osis()).toEqual("Prov.1.1")
+		expect(p.parse("SPRICHWOERTER 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("SPRICHWÖRTER 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("SPRUECHE 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPRUCHE 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("SPRÜCHE 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("PROV 1:1").osis()).toEqual("Prov.1.1")
 		expect(p.parse("SPR 1:1").osis()).toEqual("Prov.1.1")
@@ -779,13 +833,13 @@ describe "Localized book SgThree (de)", ->
 		p.include_apocrypha true
 	it "should handle book: SgThree (de)", ->
 		`
-		expect(p.parse("Lobgesang der drei jungen Manner im Feuerofen 1:1").osis()).toEqual("SgThree.1.1")
 		expect(p.parse("Lobgesang der drei jungen Männer im Feuerofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Der Gesang der Drei Manner im feurigen Ofen 1:1").osis()).toEqual("SgThree.1.1")
+		expect(p.parse("Lobgesang der drei jungen Männer im Feuerofen 1:1").osis()).toEqual("SgThree.1.1")
 		expect(p.parse("Der Gesang der Drei Männer im feurigen Ofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der drei jungen Manner 1:1").osis()).toEqual("SgThree.1.1")
+		expect(p.parse("Der Gesang der Drei Männer im feurigen Ofen 1:1").osis()).toEqual("SgThree.1.1")
 		expect(p.parse("Lobgesang der drei jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der 3 jungen Manner 1:1").osis()).toEqual("SgThree.1.1")
+		expect(p.parse("Lobgesang der drei jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
+		expect(p.parse("Lobgesang der 3 jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
 		expect(p.parse("Lobgesang der 3 jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
 		expect(p.parse("Der Gesang der Drei 1:1").osis()).toEqual("SgThree.1.1")
 		expect(p.parse("Gesang der Drei 1:1").osis()).toEqual("SgThree.1.1")
@@ -1093,11 +1147,23 @@ describe "Localized book Matt (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Matt (de)", ->
 		`
+		expect(p.parse("Das Evangelium nach Matthaus 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("Das Evangelium nach Matthäus 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("Evangelium nach Matthaus 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("Evangelium nach Matthäus 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("Matthausevangelium 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("Matthäusevangelium 1:1").osis()).toEqual("Matt.1.1")
 		expect(p.parse("Matthaus 1:1").osis()).toEqual("Matt.1.1")
 		expect(p.parse("Matthäus 1:1").osis()).toEqual("Matt.1.1")
 		expect(p.parse("Matt 1:1").osis()).toEqual("Matt.1.1")
 		expect(p.parse("Mt 1:1").osis()).toEqual("Matt.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("DAS EVANGELIUM NACH MATTHAUS 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("DAS EVANGELIUM NACH MATTHÄUS 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("EVANGELIUM NACH MATTHAUS 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("EVANGELIUM NACH MATTHÄUS 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("MATTHAUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("MATTHÄUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1")
 		expect(p.parse("MATTHAUS 1:1").osis()).toEqual("Matt.1.1")
 		expect(p.parse("MATTHÄUS 1:1").osis()).toEqual("Matt.1.1")
 		expect(p.parse("MATT 1:1").osis()).toEqual("Matt.1.1")
@@ -1112,10 +1178,16 @@ describe "Localized book Mark (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Mark (de)", ->
 		`
+		expect(p.parse("Das Evangelium nach Markus 1:1").osis()).toEqual("Mark.1.1")
+		expect(p.parse("Evangelium nach Markus 1:1").osis()).toEqual("Mark.1.1")
+		expect(p.parse("Markusevangelium 1:1").osis()).toEqual("Mark.1.1")
 		expect(p.parse("Markus 1:1").osis()).toEqual("Mark.1.1")
 		expect(p.parse("Mark 1:1").osis()).toEqual("Mark.1.1")
 		expect(p.parse("Mk 1:1").osis()).toEqual("Mark.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("DAS EVANGELIUM NACH MARKUS 1:1").osis()).toEqual("Mark.1.1")
+		expect(p.parse("EVANGELIUM NACH MARKUS 1:1").osis()).toEqual("Mark.1.1")
+		expect(p.parse("MARKUSEVANGELIUM 1:1").osis()).toEqual("Mark.1.1")
 		expect(p.parse("MARKUS 1:1").osis()).toEqual("Mark.1.1")
 		expect(p.parse("MARK 1:1").osis()).toEqual("Mark.1.1")
 		expect(p.parse("MK 1:1").osis()).toEqual("Mark.1.1")
@@ -1129,10 +1201,16 @@ describe "Localized book Luke (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Luke (de)", ->
 		`
+		expect(p.parse("Das Evangelium nach Lukas 1:1").osis()).toEqual("Luke.1.1")
+		expect(p.parse("Evangelium nach Lukas 1:1").osis()).toEqual("Luke.1.1")
+		expect(p.parse("Lukasevangelium 1:1").osis()).toEqual("Luke.1.1")
 		expect(p.parse("Lukas 1:1").osis()).toEqual("Luke.1.1")
 		expect(p.parse("Luke 1:1").osis()).toEqual("Luke.1.1")
 		expect(p.parse("Lk 1:1").osis()).toEqual("Luke.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("DAS EVANGELIUM NACH LUKAS 1:1").osis()).toEqual("Luke.1.1")
+		expect(p.parse("EVANGELIUM NACH LUKAS 1:1").osis()).toEqual("Luke.1.1")
+		expect(p.parse("LUKASEVANGELIUM 1:1").osis()).toEqual("Luke.1.1")
 		expect(p.parse("LUKAS 1:1").osis()).toEqual("Luke.1.1")
 		expect(p.parse("LUKE 1:1").osis()).toEqual("Luke.1.1")
 		expect(p.parse("LK 1:1").osis()).toEqual("Luke.1.1")
@@ -1146,6 +1224,8 @@ describe "Localized book 1John (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1John (de)", ->
 		`
+		expect(p.parse("Ersten Johannes 1:1").osis()).toEqual("1John.1.1")
+		expect(p.parse("Erstes Johannes 1:1").osis()).toEqual("1John.1.1")
 		expect(p.parse("Erste Johannes 1:1").osis()).toEqual("1John.1.1")
 		expect(p.parse("1. Johannes 1:1").osis()).toEqual("1John.1.1")
 		expect(p.parse("1 Johannes 1:1").osis()).toEqual("1John.1.1")
@@ -1153,6 +1233,8 @@ describe "Localized book 1John (de)", ->
 		expect(p.parse("1 Joh 1:1").osis()).toEqual("1John.1.1")
 		expect(p.parse("1John 1:1").osis()).toEqual("1John.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ERSTEN JOHANNES 1:1").osis()).toEqual("1John.1.1")
+		expect(p.parse("ERSTES JOHANNES 1:1").osis()).toEqual("1John.1.1")
 		expect(p.parse("ERSTE JOHANNES 1:1").osis()).toEqual("1John.1.1")
 		expect(p.parse("1. JOHANNES 1:1").osis()).toEqual("1John.1.1")
 		expect(p.parse("1 JOHANNES 1:1").osis()).toEqual("1John.1.1")
@@ -1169,6 +1251,8 @@ describe "Localized book 2John (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2John (de)", ->
 		`
+		expect(p.parse("Zweiten Johannes 1:1").osis()).toEqual("2John.1.1")
+		expect(p.parse("Zweites Johannes 1:1").osis()).toEqual("2John.1.1")
 		expect(p.parse("Zweite Johannes 1:1").osis()).toEqual("2John.1.1")
 		expect(p.parse("2. Johannes 1:1").osis()).toEqual("2John.1.1")
 		expect(p.parse("2 Johannes 1:1").osis()).toEqual("2John.1.1")
@@ -1176,6 +1260,8 @@ describe "Localized book 2John (de)", ->
 		expect(p.parse("2 Joh 1:1").osis()).toEqual("2John.1.1")
 		expect(p.parse("2John 1:1").osis()).toEqual("2John.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ZWEITEN JOHANNES 1:1").osis()).toEqual("2John.1.1")
+		expect(p.parse("ZWEITES JOHANNES 1:1").osis()).toEqual("2John.1.1")
 		expect(p.parse("ZWEITE JOHANNES 1:1").osis()).toEqual("2John.1.1")
 		expect(p.parse("2. JOHANNES 1:1").osis()).toEqual("2John.1.1")
 		expect(p.parse("2 JOHANNES 1:1").osis()).toEqual("2John.1.1")
@@ -1192,6 +1278,8 @@ describe "Localized book 3John (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 3John (de)", ->
 		`
+		expect(p.parse("Dritten Johannes 1:1").osis()).toEqual("3John.1.1")
+		expect(p.parse("Drittes Johannes 1:1").osis()).toEqual("3John.1.1")
 		expect(p.parse("Dritte Johannes 1:1").osis()).toEqual("3John.1.1")
 		expect(p.parse("3. Johannes 1:1").osis()).toEqual("3John.1.1")
 		expect(p.parse("3 Johannes 1:1").osis()).toEqual("3John.1.1")
@@ -1199,6 +1287,8 @@ describe "Localized book 3John (de)", ->
 		expect(p.parse("3 Joh 1:1").osis()).toEqual("3John.1.1")
 		expect(p.parse("3John 1:1").osis()).toEqual("3John.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("DRITTEN JOHANNES 1:1").osis()).toEqual("3John.1.1")
+		expect(p.parse("DRITTES JOHANNES 1:1").osis()).toEqual("3John.1.1")
 		expect(p.parse("DRITTE JOHANNES 1:1").osis()).toEqual("3John.1.1")
 		expect(p.parse("3. JOHANNES 1:1").osis()).toEqual("3John.1.1")
 		expect(p.parse("3 JOHANNES 1:1").osis()).toEqual("3John.1.1")
@@ -1215,10 +1305,16 @@ describe "Localized book John (de)", ->
 		p.include_apocrypha true
 	it "should handle book: John (de)", ->
 		`
+		expect(p.parse("Das Evangelium nach Johannes 1:1").osis()).toEqual("John.1.1")
+		expect(p.parse("Evangelium nach Johannes 1:1").osis()).toEqual("John.1.1")
+		expect(p.parse("Johannesevangelium 1:1").osis()).toEqual("John.1.1")
 		expect(p.parse("Johannes 1:1").osis()).toEqual("John.1.1")
 		expect(p.parse("John 1:1").osis()).toEqual("John.1.1")
 		expect(p.parse("Joh 1:1").osis()).toEqual("John.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("DAS EVANGELIUM NACH JOHANNES 1:1").osis()).toEqual("John.1.1")
+		expect(p.parse("EVANGELIUM NACH JOHANNES 1:1").osis()).toEqual("John.1.1")
+		expect(p.parse("JOHANNESEVANGELIUM 1:1").osis()).toEqual("John.1.1")
 		expect(p.parse("JOHANNES 1:1").osis()).toEqual("John.1.1")
 		expect(p.parse("JOHN 1:1").osis()).toEqual("John.1.1")
 		expect(p.parse("JOH 1:1").osis()).toEqual("John.1.1")
@@ -1250,13 +1346,11 @@ describe "Localized book Rom (de)", ->
 	it "should handle book: Rom (de)", ->
 		`
 		expect(p.parse("Roemer 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("Romer 1:1").osis()).toEqual("Rom.1.1")
 		expect(p.parse("Römer 1:1").osis()).toEqual("Rom.1.1")
 		expect(p.parse("Rom 1:1").osis()).toEqual("Rom.1.1")
 		expect(p.parse("Röm 1:1").osis()).toEqual("Rom.1.1")
 		p.include_apocrypha(false)
 		expect(p.parse("ROEMER 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("ROMER 1:1").osis()).toEqual("Rom.1.1")
 		expect(p.parse("RÖMER 1:1").osis()).toEqual("Rom.1.1")
 		expect(p.parse("ROM 1:1").osis()).toEqual("Rom.1.1")
 		expect(p.parse("RÖM 1:1").osis()).toEqual("Rom.1.1")
@@ -1270,6 +1364,8 @@ describe "Localized book 2Cor (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Cor (de)", ->
 		`
+		expect(p.parse("Zweiten Korinther 1:1").osis()).toEqual("2Cor.1.1")
+		expect(p.parse("Zweites Korinther 1:1").osis()).toEqual("2Cor.1.1")
 		expect(p.parse("Zweite Korinther 1:1").osis()).toEqual("2Cor.1.1")
 		expect(p.parse("2. Korinther 1:1").osis()).toEqual("2Cor.1.1")
 		expect(p.parse("2 Korinther 1:1").osis()).toEqual("2Cor.1.1")
@@ -1277,6 +1373,8 @@ describe "Localized book 2Cor (de)", ->
 		expect(p.parse("2 Kor 1:1").osis()).toEqual("2Cor.1.1")
 		expect(p.parse("2Cor 1:1").osis()).toEqual("2Cor.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ZWEITEN KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
+		expect(p.parse("ZWEITES KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
 		expect(p.parse("ZWEITE KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
 		expect(p.parse("2. KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
 		expect(p.parse("2 KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
@@ -1293,6 +1391,8 @@ describe "Localized book 1Cor (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Cor (de)", ->
 		`
+		expect(p.parse("Ersten Korinther 1:1").osis()).toEqual("1Cor.1.1")
+		expect(p.parse("Erstes Korinther 1:1").osis()).toEqual("1Cor.1.1")
 		expect(p.parse("Erste Korinther 1:1").osis()).toEqual("1Cor.1.1")
 		expect(p.parse("1. Korinther 1:1").osis()).toEqual("1Cor.1.1")
 		expect(p.parse("1 Korinther 1:1").osis()).toEqual("1Cor.1.1")
@@ -1300,6 +1400,8 @@ describe "Localized book 1Cor (de)", ->
 		expect(p.parse("1 Kor 1:1").osis()).toEqual("1Cor.1.1")
 		expect(p.parse("1Cor 1:1").osis()).toEqual("1Cor.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ERSTEN KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
+		expect(p.parse("ERSTES KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
 		expect(p.parse("ERSTE KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
 		expect(p.parse("1. KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
 		expect(p.parse("1 KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
@@ -1378,6 +1480,8 @@ describe "Localized book 2Thess (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Thess (de)", ->
 		`
+		expect(p.parse("Zweiten Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
+		expect(p.parse("Zweites Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
 		expect(p.parse("Zweite Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
 		expect(p.parse("2. Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
 		expect(p.parse("2 Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
@@ -1385,6 +1489,8 @@ describe "Localized book 2Thess (de)", ->
 		expect(p.parse("2 Thess 1:1").osis()).toEqual("2Thess.1.1")
 		expect(p.parse("2Thess 1:1").osis()).toEqual("2Thess.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ZWEITEN THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
+		expect(p.parse("ZWEITES THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
 		expect(p.parse("ZWEITE THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
 		expect(p.parse("2. THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
 		expect(p.parse("2 THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
@@ -1401,6 +1507,8 @@ describe "Localized book 1Thess (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Thess (de)", ->
 		`
+		expect(p.parse("Ersten Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
+		expect(p.parse("Erstes Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
 		expect(p.parse("Erste Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
 		expect(p.parse("1. Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
 		expect(p.parse("1 Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
@@ -1408,6 +1516,8 @@ describe "Localized book 1Thess (de)", ->
 		expect(p.parse("1 Thess 1:1").osis()).toEqual("1Thess.1.1")
 		expect(p.parse("1Thess 1:1").osis()).toEqual("1Thess.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ERSTEN THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
+		expect(p.parse("ERSTES THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
 		expect(p.parse("ERSTE THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
 		expect(p.parse("1. THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
 		expect(p.parse("1 THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
@@ -1424,6 +1534,8 @@ describe "Localized book 2Tim (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Tim (de)", ->
 		`
+		expect(p.parse("Zweiten Timotheus 1:1").osis()).toEqual("2Tim.1.1")
+		expect(p.parse("Zweites Timotheus 1:1").osis()).toEqual("2Tim.1.1")
 		expect(p.parse("Zweite Timotheus 1:1").osis()).toEqual("2Tim.1.1")
 		expect(p.parse("2. Timotheus 1:1").osis()).toEqual("2Tim.1.1")
 		expect(p.parse("2 Timotheus 1:1").osis()).toEqual("2Tim.1.1")
@@ -1431,6 +1543,8 @@ describe "Localized book 2Tim (de)", ->
 		expect(p.parse("2 Tim 1:1").osis()).toEqual("2Tim.1.1")
 		expect(p.parse("2Tim 1:1").osis()).toEqual("2Tim.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ZWEITEN TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
+		expect(p.parse("ZWEITES TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
 		expect(p.parse("ZWEITE TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
 		expect(p.parse("2. TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
 		expect(p.parse("2 TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
@@ -1447,6 +1561,8 @@ describe "Localized book 1Tim (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Tim (de)", ->
 		`
+		expect(p.parse("Ersten Timotheus 1:1").osis()).toEqual("1Tim.1.1")
+		expect(p.parse("Erstes Timotheus 1:1").osis()).toEqual("1Tim.1.1")
 		expect(p.parse("Erste Timotheus 1:1").osis()).toEqual("1Tim.1.1")
 		expect(p.parse("1. Timotheus 1:1").osis()).toEqual("1Tim.1.1")
 		expect(p.parse("1 Timotheus 1:1").osis()).toEqual("1Tim.1.1")
@@ -1454,6 +1570,8 @@ describe "Localized book 1Tim (de)", ->
 		expect(p.parse("1 Tim 1:1").osis()).toEqual("1Tim.1.1")
 		expect(p.parse("1Tim 1:1").osis()).toEqual("1Tim.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ERSTEN TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
+		expect(p.parse("ERSTES TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
 		expect(p.parse("ERSTE TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
 		expect(p.parse("1. TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
 		expect(p.parse("1 TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
@@ -1542,6 +1660,8 @@ describe "Localized book 2Pet (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Pet (de)", ->
 		`
+		expect(p.parse("Zweiten Petrus 1:1").osis()).toEqual("2Pet.1.1")
+		expect(p.parse("Zweites Petrus 1:1").osis()).toEqual("2Pet.1.1")
 		expect(p.parse("Zweite Petrus 1:1").osis()).toEqual("2Pet.1.1")
 		expect(p.parse("2. Petrus 1:1").osis()).toEqual("2Pet.1.1")
 		expect(p.parse("2 Petrus 1:1").osis()).toEqual("2Pet.1.1")
@@ -1549,6 +1669,8 @@ describe "Localized book 2Pet (de)", ->
 		expect(p.parse("2 Petr 1:1").osis()).toEqual("2Pet.1.1")
 		expect(p.parse("2Pet 1:1").osis()).toEqual("2Pet.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ZWEITEN PETRUS 1:1").osis()).toEqual("2Pet.1.1")
+		expect(p.parse("ZWEITES PETRUS 1:1").osis()).toEqual("2Pet.1.1")
 		expect(p.parse("ZWEITE PETRUS 1:1").osis()).toEqual("2Pet.1.1")
 		expect(p.parse("2. PETRUS 1:1").osis()).toEqual("2Pet.1.1")
 		expect(p.parse("2 PETRUS 1:1").osis()).toEqual("2Pet.1.1")
@@ -1565,6 +1687,8 @@ describe "Localized book 1Pet (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Pet (de)", ->
 		`
+		expect(p.parse("Ersten Petrus 1:1").osis()).toEqual("1Pet.1.1")
+		expect(p.parse("Erstes Petrus 1:1").osis()).toEqual("1Pet.1.1")
 		expect(p.parse("Erste Petrus 1:1").osis()).toEqual("1Pet.1.1")
 		expect(p.parse("1. Petrus 1:1").osis()).toEqual("1Pet.1.1")
 		expect(p.parse("1 Petrus 1:1").osis()).toEqual("1Pet.1.1")
@@ -1572,6 +1696,8 @@ describe "Localized book 1Pet (de)", ->
 		expect(p.parse("1 Petr 1:1").osis()).toEqual("1Pet.1.1")
 		expect(p.parse("1Pet 1:1").osis()).toEqual("1Pet.1.1")
 		p.include_apocrypha(false)
+		expect(p.parse("ERSTEN PETRUS 1:1").osis()).toEqual("1Pet.1.1")
+		expect(p.parse("ERSTES PETRUS 1:1").osis()).toEqual("1Pet.1.1")
 		expect(p.parse("ERSTE PETRUS 1:1").osis()).toEqual("1Pet.1.1")
 		expect(p.parse("1. PETRUS 1:1").osis()).toEqual("1Pet.1.1")
 		expect(p.parse("1 PETRUS 1:1").osis()).toEqual("1Pet.1.1")
@@ -1656,6 +1782,10 @@ describe "Localized book 2Macc (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Macc (de)", ->
 		`
+		expect(p.parse("Zweiten Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
+		expect(p.parse("Zweiten Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
+		expect(p.parse("Zweites Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
+		expect(p.parse("Zweites Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
 		expect(p.parse("Zweite Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
 		expect(p.parse("Zweite Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
 		expect(p.parse("2. Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
@@ -1675,6 +1805,10 @@ describe "Localized book 3Macc (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 3Macc (de)", ->
 		`
+		expect(p.parse("Dritten Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
+		expect(p.parse("Dritten Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
+		expect(p.parse("Drittes Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
+		expect(p.parse("Drittes Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
 		expect(p.parse("Dritte Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
 		expect(p.parse("Dritte Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
 		expect(p.parse("3. Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
@@ -1694,6 +1828,10 @@ describe "Localized book 4Macc (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 4Macc (de)", ->
 		`
+		expect(p.parse("Vierten Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
+		expect(p.parse("Vierten Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
+		expect(p.parse("Viertes Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
+		expect(p.parse("Viertes Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
 		expect(p.parse("Vierte Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
 		expect(p.parse("Vierte Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
 		expect(p.parse("4. Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
@@ -1713,6 +1851,10 @@ describe "Localized book 1Macc (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Macc (de)", ->
 		`
+		expect(p.parse("Ersten Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
+		expect(p.parse("Ersten Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
+		expect(p.parse("Erstes Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
+		expect(p.parse("Erstes Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
 		expect(p.parse("Erste Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
 		expect(p.parse("Erste Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
 		expect(p.parse("1. Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
@@ -1766,6 +1908,10 @@ describe "Miscellaneous tests", ->
 		expect(p.parse("Matt 1bis2").osis()).toEqual "Matt.1-Matt.2"
 		expect(p.parse("Phlm 2 BIS 3").osis()).toEqual "Phlm.1.2-Phlm.1.3"
 	it "should handle chapters (de)", ->
+		expect(p.parse("Titus 1:1, Kapitels 2").osis()).toEqual "Titus.1.1,Titus.2"
+		expect(p.parse("Matt 3:4 KAPITELS 6").osis()).toEqual "Matt.3.4,Matt.6"
+		expect(p.parse("Titus 1:1, Kapiteln 2").osis()).toEqual "Titus.1.1,Titus.2"
+		expect(p.parse("Matt 3:4 KAPITELN 6").osis()).toEqual "Matt.3.4,Matt.6"
 		expect(p.parse("Titus 1:1, Kapitel 2").osis()).toEqual "Titus.1.1,Titus.2"
 		expect(p.parse("Matt 3:4 KAPITEL 6").osis()).toEqual "Matt.3.4,Matt.6"
 		expect(p.parse("Titus 1:1, Kap. 2").osis()).toEqual "Titus.1.1,Titus.2"
@@ -1773,10 +1919,16 @@ describe "Miscellaneous tests", ->
 		expect(p.parse("Titus 1:1, Kap 2").osis()).toEqual "Titus.1.1,Titus.2"
 		expect(p.parse("Matt 3:4 KAP 6").osis()).toEqual "Matt.3.4,Matt.6"
 	it "should handle verses (de)", ->
+		expect(p.parse("Exod 1:1 Verses 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm VERSES 6").osis()).toEqual "Phlm.1.6"
+		expect(p.parse("Exod 1:1 Versen 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm VERSEN 6").osis()).toEqual "Phlm.1.6"
 		expect(p.parse("Exod 1:1 Verse 3").osis()).toEqual "Exod.1.1,Exod.1.3"
 		expect(p.parse("Phlm VERSE 6").osis()).toEqual "Phlm.1.6"
 		expect(p.parse("Exod 1:1 Vers. 3").osis()).toEqual "Exod.1.1,Exod.1.3"
 		expect(p.parse("Phlm VERS. 6").osis()).toEqual "Phlm.1.6"
+		expect(p.parse("Exod 1:1 Vers 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm VERS 6").osis()).toEqual "Phlm.1.6"
 		expect(p.parse("Exod 1:1 Vers 3").osis()).toEqual "Exod.1.1,Exod.1.3"
 		expect(p.parse("Phlm VERS 6").osis()).toEqual "Phlm.1.6"
 		expect(p.parse("Exod 1:1 Ver. 3").osis()).toEqual "Exod.1.1,Exod.1.3"
@@ -1790,16 +1942,32 @@ describe "Miscellaneous tests", ->
 	it "should handle 'and' (de)", ->
 		expect(p.parse("Exod 1:1 und 3").osis()).toEqual "Exod.1.1,Exod.1.3"
 		expect(p.parse("Phlm 2 UND 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
+		expect(p.parse("Exod 1:1 u. 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm 2 U. 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
+		expect(p.parse("Exod 1:1 u 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm 2 U 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
+		expect(p.parse("Exod 1:1 & 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm 2 & 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
 		expect(p.parse("Exod 1:1 vgl. 3").osis()).toEqual "Exod.1.1,Exod.1.3"
 		expect(p.parse("Phlm 2 VGL. 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
 		expect(p.parse("Exod 1:1 vgl 3").osis()).toEqual "Exod.1.1,Exod.1.3"
 		expect(p.parse("Phlm 2 VGL 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
+		expect(p.parse("Exod 1:1 sowie 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm 2 SOWIE 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
+		expect(p.parse("Exod 1:1 und auch 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm 2 UND AUCH 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
+		expect(p.parse("Exod 1:1 und siehe auch 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm 2 UND SIEHE AUCH 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
+		expect(p.parse("Exod 1:1 siehe auch 3").osis()).toEqual "Exod.1.1,Exod.1.3"
+		expect(p.parse("Phlm 2 SIEHE AUCH 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
 	it "should handle titles (de)", ->
 		expect(p.parse("Ps 3 Titel, 4:2, 5:Titel").osis()).toEqual "Ps.3.1,Ps.4.2,Ps.5.1"
 		expect(p.parse("PS 3 TITEL, 4:2, 5:TITEL").osis()).toEqual "Ps.3.1,Ps.4.2,Ps.5.1"
 	it "should handle 'ff' (de)", ->
 		expect(p.parse("Rev 3ff, 4:2ff").osis()).toEqual "Rev.3-Rev.22,Rev.4.2-Rev.4.11"
 		expect(p.parse("REV 3 FF, 4:2 FF").osis()).toEqual "Rev.3-Rev.22,Rev.4.2-Rev.4.11"
+		expect(p.parse("Rev 3f, 4:2f").osis()).toEqual "Rev.3-Rev.22,Rev.4.2-Rev.4.11"
+		expect(p.parse("REV 3 F, 4:2 F").osis()).toEqual "Rev.3-Rev.22,Rev.4.2-Rev.4.11"
 	it "should handle translations (de)", ->
 		expect(p.parse("Lev 1 (ELB)").osis_and_translations()).toEqual [["Lev.1", "ELB"]]
 		expect(p.parse("lev 1 elb").osis_and_translations()).toEqual [["Lev.1", "ELB"]]
@@ -1815,7 +1983,7 @@ describe "Miscellaneous tests", ->
 		expect(p.parse("lev 1 sch2000").osis_and_translations()).toEqual [["Lev.1", "SCH2000"]]
 	it "should handle book ranges (de)", ->
 		p.set_options {book_alone_strategy: "full", book_range_strategy: "include"}
-		expect(p.parse("Erste bis Dritte  Johannes").osis()).toEqual "1John.1-3John.1"
+		expect(p.parse("Erstes bis Drittes  Johannes").osis()).toEqual "1John.1-3John.1"
 	it "should handle boundaries (de)", ->
 		p.set_options {book_alone_strategy: "full"}
 		expect(p.parse("\u2014Matt\u2014").osis()).toEqual "Matt.1-Matt.28"

--- a/src/de/spec.coffee
+++ b/src/de/spec.coffee
@@ -52,39 +52,45 @@ describe "Localized book Gen (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Gen (de)", ->
 		`
-		expect(p.parse("Ersten Buch Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Erstes Buch Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Erste Buch Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. Buch Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 Buch Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Ersten Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Erstes Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Erste Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Genesis 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. Mos 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 Mos 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. Mo 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 Mo 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Gen 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("Ersten Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Ersten Buch Mose 1:1'")
+		expect(p.parse("Erster Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erster Buch Mose 1:1'")
+		expect(p.parse("Erstes Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erstes Buch Mose 1:1'")
+		expect(p.parse("Erste Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erste Buch Mose 1:1'")
+		expect(p.parse("1. Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. Buch Mose 1:1'")
+		expect(p.parse("1 Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 Buch Mose 1:1'")
+		expect(p.parse("Ersten Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Ersten Mose 1:1'")
+		expect(p.parse("Erster Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erster Mose 1:1'")
+		expect(p.parse("Erstes Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erstes Mose 1:1'")
+		expect(p.parse("Erste Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erste Mose 1:1'")
+		expect(p.parse("1. Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. Mose 1:1'")
+		expect(p.parse("Genesis 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Genesis 1:1'")
+		expect(p.parse("1 Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 Mose 1:1'")
+		expect(p.parse("1. Mos 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. Mos 1:1'")
+		expect(p.parse("1 Mos 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 Mos 1:1'")
+		expect(p.parse("1. Mo 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. Mo 1:1'")
+		expect(p.parse("1 Mo 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 Mo 1:1'")
+		expect(p.parse("Gen 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Gen 1:1'")
+		expect(p.parse("Gn 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Gn 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTEN BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("ERSTES BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("ERSTE BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("ERSTEN MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("ERSTES MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("ERSTE MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("GENESIS 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. MOS 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 MOS 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. MO 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 MO 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("GEN 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("ERSTEN BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTEN BUCH MOSE 1:1'")
+		expect(p.parse("ERSTER BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTER BUCH MOSE 1:1'")
+		expect(p.parse("ERSTES BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTES BUCH MOSE 1:1'")
+		expect(p.parse("ERSTE BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTE BUCH MOSE 1:1'")
+		expect(p.parse("1. BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. BUCH MOSE 1:1'")
+		expect(p.parse("1 BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 BUCH MOSE 1:1'")
+		expect(p.parse("ERSTEN MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTEN MOSE 1:1'")
+		expect(p.parse("ERSTER MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTER MOSE 1:1'")
+		expect(p.parse("ERSTES MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTES MOSE 1:1'")
+		expect(p.parse("ERSTE MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTE MOSE 1:1'")
+		expect(p.parse("1. MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. MOSE 1:1'")
+		expect(p.parse("GENESIS 1:1").osis()).toEqual("Gen.1.1", "parsing: 'GENESIS 1:1'")
+		expect(p.parse("1 MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 MOSE 1:1'")
+		expect(p.parse("1. MOS 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. MOS 1:1'")
+		expect(p.parse("1 MOS 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 MOS 1:1'")
+		expect(p.parse("1. MO 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. MO 1:1'")
+		expect(p.parse("1 MO 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 MO 1:1'")
+		expect(p.parse("GEN 1:1").osis()).toEqual("Gen.1.1", "parsing: 'GEN 1:1'")
+		expect(p.parse("GN 1:1").osis()).toEqual("Gen.1.1", "parsing: 'GN 1:1'")
 		`
 		true
 describe "Localized book Exod (de)", ->
@@ -95,41 +101,45 @@ describe "Localized book Exod (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Exod (de)", ->
 		`
-		expect(p.parse("Zweiten Buch Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Zweites Buch Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Zweite Buch Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. Buch Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Zweiten Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Zweites Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 Buch Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Zweite Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. Mos 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Exodus 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 Mos 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. Mo 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 Mo 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Exod 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Ex 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("Zweiten Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweiten Buch Mose 1:1'")
+		expect(p.parse("Zweiter Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweiter Buch Mose 1:1'")
+		expect(p.parse("Zweites Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweites Buch Mose 1:1'")
+		expect(p.parse("Zweite Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweite Buch Mose 1:1'")
+		expect(p.parse("2. Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. Buch Mose 1:1'")
+		expect(p.parse("Zweiten Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweiten Mose 1:1'")
+		expect(p.parse("Zweiter Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweiter Mose 1:1'")
+		expect(p.parse("Zweites Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweites Mose 1:1'")
+		expect(p.parse("2 Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 Buch Mose 1:1'")
+		expect(p.parse("Zweite Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweite Mose 1:1'")
+		expect(p.parse("2. Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. Mose 1:1'")
+		expect(p.parse("2 Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 Mose 1:1'")
+		expect(p.parse("2. Mos 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. Mos 1:1'")
+		expect(p.parse("Exodus 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Exodus 1:1'")
+		expect(p.parse("2 Mos 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 Mos 1:1'")
+		expect(p.parse("2. Mo 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. Mo 1:1'")
+		expect(p.parse("2 Mo 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 Mo 1:1'")
+		expect(p.parse("Exod 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Exod 1:1'")
+		expect(p.parse("Ex 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Ex 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITEN BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("ZWEITES BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("ZWEITE BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("ZWEITEN MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("ZWEITES MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("ZWEITE MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. MOS 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("EXODUS 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 MOS 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. MO 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 MO 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("EXOD 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("EX 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("ZWEITEN BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITEN BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITER BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITER BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITES BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITES BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITE BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITE BUCH MOSE 1:1'")
+		expect(p.parse("2. BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITEN MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITEN MOSE 1:1'")
+		expect(p.parse("ZWEITER MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITER MOSE 1:1'")
+		expect(p.parse("ZWEITES MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITES MOSE 1:1'")
+		expect(p.parse("2 BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITE MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITE MOSE 1:1'")
+		expect(p.parse("2. MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. MOSE 1:1'")
+		expect(p.parse("2 MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 MOSE 1:1'")
+		expect(p.parse("2. MOS 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. MOS 1:1'")
+		expect(p.parse("EXODUS 1:1").osis()).toEqual("Exod.1.1", "parsing: 'EXODUS 1:1'")
+		expect(p.parse("2 MOS 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 MOS 1:1'")
+		expect(p.parse("2. MO 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. MO 1:1'")
+		expect(p.parse("2 MO 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 MO 1:1'")
+		expect(p.parse("EXOD 1:1").osis()).toEqual("Exod.1.1", "parsing: 'EXOD 1:1'")
+		expect(p.parse("EX 1:1").osis()).toEqual("Exod.1.1", "parsing: 'EX 1:1'")
 		`
 		true
 describe "Localized book Bel (de)", ->
@@ -140,8 +150,10 @@ describe "Localized book Bel (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Bel (de)", ->
 		`
-		expect(p.parse("Bel und Vom Drachen 1:1").osis()).toEqual("Bel.1.1")
-		expect(p.parse("Bel 1:1").osis()).toEqual("Bel.1.1")
+		expect(p.parse("Bel und Vom Drachen 1:1").osis()).toEqual("Bel.1.1", "parsing: 'Bel und Vom Drachen 1:1'")
+		expect(p.parse("Bel und der Drache 1:1").osis()).toEqual("Bel.1.1", "parsing: 'Bel und der Drache 1:1'")
+		expect(p.parse("Bel und de Drache 1:1").osis()).toEqual("Bel.1.1", "parsing: 'Bel und de Drache 1:1'")
+		expect(p.parse("Bel 1:1").osis()).toEqual("Bel.1.1", "parsing: 'Bel 1:1'")
 		`
 		true
 describe "Localized book Lev (de)", ->
@@ -152,39 +164,45 @@ describe "Localized book Lev (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Lev (de)", ->
 		`
-		expect(p.parse("Dritten Buch Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Drittes Buch Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Dritte Buch Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. Buch Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Dritten Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Drittes Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 Buch Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Dritte Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Levitikus 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. Mos 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 Mos 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. Mo 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 Mo 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Lev 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("Dritten Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritten Buch Mose 1:1'")
+		expect(p.parse("Dritter Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritter Buch Mose 1:1'")
+		expect(p.parse("Drittes Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Drittes Buch Mose 1:1'")
+		expect(p.parse("Dritte Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritte Buch Mose 1:1'")
+		expect(p.parse("3. Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. Buch Mose 1:1'")
+		expect(p.parse("Dritten Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritten Mose 1:1'")
+		expect(p.parse("Dritter Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritter Mose 1:1'")
+		expect(p.parse("Drittes Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Drittes Mose 1:1'")
+		expect(p.parse("3 Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 Buch Mose 1:1'")
+		expect(p.parse("Dritte Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritte Mose 1:1'")
+		expect(p.parse("Levitikus 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Levitikus 1:1'")
+		expect(p.parse("3. Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. Mose 1:1'")
+		expect(p.parse("3 Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 Mose 1:1'")
+		expect(p.parse("3. Mos 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. Mos 1:1'")
+		expect(p.parse("3 Mos 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 Mos 1:1'")
+		expect(p.parse("3. Mo 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. Mo 1:1'")
+		expect(p.parse("3 Mo 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 Mo 1:1'")
+		expect(p.parse("Lev 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Lev 1:1'")
+		expect(p.parse("Lv 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Lv 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DRITTEN BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("DRITTES BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("DRITTE BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("DRITTEN MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("DRITTES MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("DRITTE MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("LEVITIKUS 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. MOS 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 MOS 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. MO 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 MO 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("LEV 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("DRITTEN BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTEN BUCH MOSE 1:1'")
+		expect(p.parse("DRITTER BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTER BUCH MOSE 1:1'")
+		expect(p.parse("DRITTES BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTES BUCH MOSE 1:1'")
+		expect(p.parse("DRITTE BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTE BUCH MOSE 1:1'")
+		expect(p.parse("3. BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. BUCH MOSE 1:1'")
+		expect(p.parse("DRITTEN MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTEN MOSE 1:1'")
+		expect(p.parse("DRITTER MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTER MOSE 1:1'")
+		expect(p.parse("DRITTES MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTES MOSE 1:1'")
+		expect(p.parse("3 BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 BUCH MOSE 1:1'")
+		expect(p.parse("DRITTE MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTE MOSE 1:1'")
+		expect(p.parse("LEVITIKUS 1:1").osis()).toEqual("Lev.1.1", "parsing: 'LEVITIKUS 1:1'")
+		expect(p.parse("3. MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. MOSE 1:1'")
+		expect(p.parse("3 MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 MOSE 1:1'")
+		expect(p.parse("3. MOS 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. MOS 1:1'")
+		expect(p.parse("3 MOS 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 MOS 1:1'")
+		expect(p.parse("3. MO 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. MO 1:1'")
+		expect(p.parse("3 MO 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 MO 1:1'")
+		expect(p.parse("LEV 1:1").osis()).toEqual("Lev.1.1", "parsing: 'LEV 1:1'")
+		expect(p.parse("LV 1:1").osis()).toEqual("Lev.1.1", "parsing: 'LV 1:1'")
 		`
 		true
 describe "Localized book Num (de)", ->
@@ -195,39 +213,41 @@ describe "Localized book Num (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Num (de)", ->
 		`
-		expect(p.parse("Vierten Buch Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Viertes Buch Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Vierte Buch Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. Buch Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Vierten Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Viertes Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 Buch Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Vierte Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. Mos 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Numeri 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 Mos 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. Mo 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 Mo 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Num 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("Vierten Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Vierten Buch Mose 1:1'")
+		expect(p.parse("Viertes Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Viertes Buch Mose 1:1'")
+		expect(p.parse("Vierte Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Vierte Buch Mose 1:1'")
+		expect(p.parse("4. Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: '4. Buch Mose 1:1'")
+		expect(p.parse("Vierten Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Vierten Mose 1:1'")
+		expect(p.parse("Viertes Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Viertes Mose 1:1'")
+		expect(p.parse("4 Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: '4 Buch Mose 1:1'")
+		expect(p.parse("Vierte Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Vierte Mose 1:1'")
+		expect(p.parse("4. Mose 1:1").osis()).toEqual("Num.1.1", "parsing: '4. Mose 1:1'")
+		expect(p.parse("4 Mose 1:1").osis()).toEqual("Num.1.1", "parsing: '4 Mose 1:1'")
+		expect(p.parse("4. Mos 1:1").osis()).toEqual("Num.1.1", "parsing: '4. Mos 1:1'")
+		expect(p.parse("Numeri 1:1").osis()).toEqual("Num.1.1", "parsing: 'Numeri 1:1'")
+		expect(p.parse("4 Mos 1:1").osis()).toEqual("Num.1.1", "parsing: '4 Mos 1:1'")
+		expect(p.parse("4. Mo 1:1").osis()).toEqual("Num.1.1", "parsing: '4. Mo 1:1'")
+		expect(p.parse("4 Mo 1:1").osis()).toEqual("Num.1.1", "parsing: '4 Mo 1:1'")
+		expect(p.parse("Num 1:1").osis()).toEqual("Num.1.1", "parsing: 'Num 1:1'")
+		expect(p.parse("Nm 1:1").osis()).toEqual("Num.1.1", "parsing: 'Nm 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("VIERTEN BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("VIERTES BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("VIERTE BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("VIERTEN MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("VIERTES MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("VIERTE MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. MOS 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("NUMERI 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 MOS 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. MO 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 MO 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("NUM 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("VIERTEN BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTEN BUCH MOSE 1:1'")
+		expect(p.parse("VIERTES BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTES BUCH MOSE 1:1'")
+		expect(p.parse("VIERTE BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTE BUCH MOSE 1:1'")
+		expect(p.parse("4. BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: '4. BUCH MOSE 1:1'")
+		expect(p.parse("VIERTEN MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTEN MOSE 1:1'")
+		expect(p.parse("VIERTES MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTES MOSE 1:1'")
+		expect(p.parse("4 BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: '4 BUCH MOSE 1:1'")
+		expect(p.parse("VIERTE MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTE MOSE 1:1'")
+		expect(p.parse("4. MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: '4. MOSE 1:1'")
+		expect(p.parse("4 MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: '4 MOSE 1:1'")
+		expect(p.parse("4. MOS 1:1").osis()).toEqual("Num.1.1", "parsing: '4. MOS 1:1'")
+		expect(p.parse("NUMERI 1:1").osis()).toEqual("Num.1.1", "parsing: 'NUMERI 1:1'")
+		expect(p.parse("4 MOS 1:1").osis()).toEqual("Num.1.1", "parsing: '4 MOS 1:1'")
+		expect(p.parse("4. MO 1:1").osis()).toEqual("Num.1.1", "parsing: '4. MO 1:1'")
+		expect(p.parse("4 MO 1:1").osis()).toEqual("Num.1.1", "parsing: '4 MO 1:1'")
+		expect(p.parse("NUM 1:1").osis()).toEqual("Num.1.1", "parsing: 'NUM 1:1'")
+		expect(p.parse("NM 1:1").osis()).toEqual("Num.1.1", "parsing: 'NM 1:1'")
 		`
 		true
 describe "Localized book Sir (de)", ->
@@ -238,9 +258,9 @@ describe "Localized book Sir (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Sir (de)", ->
 		`
-		expect(p.parse("Ecclesiasticus 1:1").osis()).toEqual("Sir.1.1")
-		expect(p.parse("Jesus Sirach 1:1").osis()).toEqual("Sir.1.1")
-		expect(p.parse("Sir 1:1").osis()).toEqual("Sir.1.1")
+		expect(p.parse("Ecclesiasticus 1:1").osis()).toEqual("Sir.1.1", "parsing: 'Ecclesiasticus 1:1'")
+		expect(p.parse("Jesus Sirach 1:1").osis()).toEqual("Sir.1.1", "parsing: 'Jesus Sirach 1:1'")
+		expect(p.parse("Sir 1:1").osis()).toEqual("Sir.1.1", "parsing: 'Sir 1:1'")
 		`
 		true
 describe "Localized book Wis (de)", ->
@@ -251,10 +271,10 @@ describe "Localized book Wis (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Wis (de)", ->
 		`
-		expect(p.parse("Weisheit Salomos 1:1").osis()).toEqual("Wis.1.1")
-		expect(p.parse("Weisheit 1:1").osis()).toEqual("Wis.1.1")
-		expect(p.parse("Weish 1:1").osis()).toEqual("Wis.1.1")
-		expect(p.parse("Wis 1:1").osis()).toEqual("Wis.1.1")
+		expect(p.parse("Weisheit Salomos 1:1").osis()).toEqual("Wis.1.1", "parsing: 'Weisheit Salomos 1:1'")
+		expect(p.parse("Weisheit 1:1").osis()).toEqual("Wis.1.1", "parsing: 'Weisheit 1:1'")
+		expect(p.parse("Weish 1:1").osis()).toEqual("Wis.1.1", "parsing: 'Weish 1:1'")
+		expect(p.parse("Wis 1:1").osis()).toEqual("Wis.1.1", "parsing: 'Wis 1:1'")
 		`
 		true
 describe "Localized book Lam (de)", ->
@@ -265,17 +285,17 @@ describe "Localized book Lam (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Lam (de)", ->
 		`
-		expect(p.parse("Klagelieder Jeremias 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("Klagelieder 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("Klag 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("Klgl 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("Lam 1:1").osis()).toEqual("Lam.1.1")
+		expect(p.parse("Klagelieder Jeremias 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Klagelieder Jeremias 1:1'")
+		expect(p.parse("Klagelieder 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Klagelieder 1:1'")
+		expect(p.parse("Klag 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Klag 1:1'")
+		expect(p.parse("Klgl 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Klgl 1:1'")
+		expect(p.parse("Lam 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Lam 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("KLAGELIEDER JEREMIAS 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("KLAGELIEDER 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("KLAG 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("KLGL 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("LAM 1:1").osis()).toEqual("Lam.1.1")
+		expect(p.parse("KLAGELIEDER JEREMIAS 1:1").osis()).toEqual("Lam.1.1", "parsing: 'KLAGELIEDER JEREMIAS 1:1'")
+		expect(p.parse("KLAGELIEDER 1:1").osis()).toEqual("Lam.1.1", "parsing: 'KLAGELIEDER 1:1'")
+		expect(p.parse("KLAG 1:1").osis()).toEqual("Lam.1.1", "parsing: 'KLAG 1:1'")
+		expect(p.parse("KLGL 1:1").osis()).toEqual("Lam.1.1", "parsing: 'KLGL 1:1'")
+		expect(p.parse("LAM 1:1").osis()).toEqual("Lam.1.1", "parsing: 'LAM 1:1'")
 		`
 		true
 describe "Localized book EpJer (de)", ->
@@ -286,9 +306,9 @@ describe "Localized book EpJer (de)", ->
 		p.include_apocrypha true
 	it "should handle book: EpJer (de)", ->
 		`
-		expect(p.parse("Brief des Jeremia 1:1").osis()).toEqual("EpJer.1.1")
-		expect(p.parse("Br Jer 1:1").osis()).toEqual("EpJer.1.1")
-		expect(p.parse("EpJer 1:1").osis()).toEqual("EpJer.1.1")
+		expect(p.parse("Brief des Jeremia 1:1").osis()).toEqual("EpJer.1.1", "parsing: 'Brief des Jeremia 1:1'")
+		expect(p.parse("Br Jer 1:1").osis()).toEqual("EpJer.1.1", "parsing: 'Br Jer 1:1'")
+		expect(p.parse("EpJer 1:1").osis()).toEqual("EpJer.1.1", "parsing: 'EpJer 1:1'")
 		`
 		true
 describe "Localized book Rev (de)", ->
@@ -299,13 +319,13 @@ describe "Localized book Rev (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Rev (de)", ->
 		`
-		expect(p.parse("Offenbarung 1:1").osis()).toEqual("Rev.1.1")
-		expect(p.parse("Offb 1:1").osis()).toEqual("Rev.1.1")
-		expect(p.parse("Rev 1:1").osis()).toEqual("Rev.1.1")
+		expect(p.parse("Offenbarung 1:1").osis()).toEqual("Rev.1.1", "parsing: 'Offenbarung 1:1'")
+		expect(p.parse("Offb 1:1").osis()).toEqual("Rev.1.1", "parsing: 'Offb 1:1'")
+		expect(p.parse("Rev 1:1").osis()).toEqual("Rev.1.1", "parsing: 'Rev 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("OFFENBARUNG 1:1").osis()).toEqual("Rev.1.1")
-		expect(p.parse("OFFB 1:1").osis()).toEqual("Rev.1.1")
-		expect(p.parse("REV 1:1").osis()).toEqual("Rev.1.1")
+		expect(p.parse("OFFENBARUNG 1:1").osis()).toEqual("Rev.1.1", "parsing: 'OFFENBARUNG 1:1'")
+		expect(p.parse("OFFB 1:1").osis()).toEqual("Rev.1.1", "parsing: 'OFFB 1:1'")
+		expect(p.parse("REV 1:1").osis()).toEqual("Rev.1.1", "parsing: 'REV 1:1'")
 		`
 		true
 describe "Localized book PrMan (de)", ->
@@ -316,12 +336,14 @@ describe "Localized book PrMan (de)", ->
 		p.include_apocrypha true
 	it "should handle book: PrMan (de)", ->
 		`
-		expect(p.parse("Gebet des Manasse 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("Gebet Manasses 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("Gebet Manasse 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("Geb Man 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("Or Man 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("PrMan 1:1").osis()).toEqual("PrMan.1.1")
+		expect(p.parse("Das Gebet des Manasse 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Das Gebet des Manasse 1:1'")
+		expect(p.parse("Das Gebet Manasses 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Das Gebet Manasses 1:1'")
+		expect(p.parse("Gebet des Manasse 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Gebet des Manasse 1:1'")
+		expect(p.parse("Gebet Manasses 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Gebet Manasses 1:1'")
+		expect(p.parse("Gebet Manasse 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Gebet Manasse 1:1'")
+		expect(p.parse("Geb Man 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Geb Man 1:1'")
+		expect(p.parse("Or Man 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Or Man 1:1'")
+		expect(p.parse("PrMan 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'PrMan 1:1'")
 		`
 		true
 describe "Localized book Deut (de)", ->
@@ -332,41 +354,39 @@ describe "Localized book Deut (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Deut (de)", ->
 		`
-		expect(p.parse("Fünften Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Fünftes Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Fünfte Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Deuteronomium 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Fünften Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Fünftes Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Fünfte Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. Mos 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 Mos 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. Mo 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 Mo 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Deut 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Dtn 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("Funftes Buch Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Funftes Buch Mose 1:1'")
+		expect(p.parse("Fünftes Buch Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Fünftes Buch Mose 1:1'")
+		expect(p.parse("Deuteronomium 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Deuteronomium 1:1'")
+		expect(p.parse("5. Buch Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. Buch Mose 1:1'")
+		expect(p.parse("Funftes Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Funftes Mose 1:1'")
+		expect(p.parse("Fünftes Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Fünftes Mose 1:1'")
+		expect(p.parse("5 Buch Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 Buch Mose 1:1'")
+		expect(p.parse("5. Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. Mose 1:1'")
+		expect(p.parse("5 Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 Mose 1:1'")
+		expect(p.parse("5. Mos 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. Mos 1:1'")
+		expect(p.parse("5 Mos 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 Mos 1:1'")
+		expect(p.parse("5. Mo 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. Mo 1:1'")
+		expect(p.parse("5 Mo 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 Mo 1:1'")
+		expect(p.parse("Deut 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Deut 1:1'")
+		expect(p.parse("Dtn 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Dtn 1:1'")
+		expect(p.parse("Dt 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Dt 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("FÜNFTEN BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("FÜNFTES BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("FÜNFTE BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("DEUTERONOMIUM 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("FÜNFTEN MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("FÜNFTES MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("FÜNFTE MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. MOS 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 MOS 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. MO 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 MO 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("DEUT 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("DTN 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("FUNFTES BUCH MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: 'FUNFTES BUCH MOSE 1:1'")
+		expect(p.parse("FÜNFTES BUCH MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: 'FÜNFTES BUCH MOSE 1:1'")
+		expect(p.parse("DEUTERONOMIUM 1:1").osis()).toEqual("Deut.1.1", "parsing: 'DEUTERONOMIUM 1:1'")
+		expect(p.parse("5. BUCH MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. BUCH MOSE 1:1'")
+		expect(p.parse("FUNFTES MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: 'FUNFTES MOSE 1:1'")
+		expect(p.parse("FÜNFTES MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: 'FÜNFTES MOSE 1:1'")
+		expect(p.parse("5 BUCH MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 BUCH MOSE 1:1'")
+		expect(p.parse("5. MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. MOSE 1:1'")
+		expect(p.parse("5 MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 MOSE 1:1'")
+		expect(p.parse("5. MOS 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. MOS 1:1'")
+		expect(p.parse("5 MOS 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 MOS 1:1'")
+		expect(p.parse("5. MO 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. MO 1:1'")
+		expect(p.parse("5 MO 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 MO 1:1'")
+		expect(p.parse("DEUT 1:1").osis()).toEqual("Deut.1.1", "parsing: 'DEUT 1:1'")
+		expect(p.parse("DTN 1:1").osis()).toEqual("Deut.1.1", "parsing: 'DTN 1:1'")
+		expect(p.parse("DT 1:1").osis()).toEqual("Deut.1.1", "parsing: 'DT 1:1'")
 		`
 		true
 describe "Localized book Josh (de)", ->
@@ -377,13 +397,13 @@ describe "Localized book Josh (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Josh (de)", ->
 		`
-		expect(p.parse("Josua 1:1").osis()).toEqual("Josh.1.1")
-		expect(p.parse("Josh 1:1").osis()).toEqual("Josh.1.1")
-		expect(p.parse("Jos 1:1").osis()).toEqual("Josh.1.1")
+		expect(p.parse("Josua 1:1").osis()).toEqual("Josh.1.1", "parsing: 'Josua 1:1'")
+		expect(p.parse("Josh 1:1").osis()).toEqual("Josh.1.1", "parsing: 'Josh 1:1'")
+		expect(p.parse("Jos 1:1").osis()).toEqual("Josh.1.1", "parsing: 'Jos 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JOSUA 1:1").osis()).toEqual("Josh.1.1")
-		expect(p.parse("JOSH 1:1").osis()).toEqual("Josh.1.1")
-		expect(p.parse("JOS 1:1").osis()).toEqual("Josh.1.1")
+		expect(p.parse("JOSUA 1:1").osis()).toEqual("Josh.1.1", "parsing: 'JOSUA 1:1'")
+		expect(p.parse("JOSH 1:1").osis()).toEqual("Josh.1.1", "parsing: 'JOSH 1:1'")
+		expect(p.parse("JOS 1:1").osis()).toEqual("Josh.1.1", "parsing: 'JOS 1:1'")
 		`
 		true
 describe "Localized book Judg (de)", ->
@@ -394,13 +414,15 @@ describe "Localized book Judg (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Judg (de)", ->
 		`
-		expect(p.parse("Richter 1:1").osis()).toEqual("Judg.1.1")
-		expect(p.parse("Judg 1:1").osis()).toEqual("Judg.1.1")
-		expect(p.parse("Ri 1:1").osis()).toEqual("Judg.1.1")
+		expect(p.parse("Richter 1:1").osis()).toEqual("Judg.1.1", "parsing: 'Richter 1:1'")
+		expect(p.parse("Judg 1:1").osis()).toEqual("Judg.1.1", "parsing: 'Judg 1:1'")
+		expect(p.parse("Rich 1:1").osis()).toEqual("Judg.1.1", "parsing: 'Rich 1:1'")
+		expect(p.parse("Ri 1:1").osis()).toEqual("Judg.1.1", "parsing: 'Ri 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("RICHTER 1:1").osis()).toEqual("Judg.1.1")
-		expect(p.parse("JUDG 1:1").osis()).toEqual("Judg.1.1")
-		expect(p.parse("RI 1:1").osis()).toEqual("Judg.1.1")
+		expect(p.parse("RICHTER 1:1").osis()).toEqual("Judg.1.1", "parsing: 'RICHTER 1:1'")
+		expect(p.parse("JUDG 1:1").osis()).toEqual("Judg.1.1", "parsing: 'JUDG 1:1'")
+		expect(p.parse("RICH 1:1").osis()).toEqual("Judg.1.1", "parsing: 'RICH 1:1'")
+		expect(p.parse("RI 1:1").osis()).toEqual("Judg.1.1", "parsing: 'RI 1:1'")
 		`
 		true
 describe "Localized book Ruth (de)", ->
@@ -411,11 +433,13 @@ describe "Localized book Ruth (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Ruth (de)", ->
 		`
-		expect(p.parse("Ruth 1:1").osis()).toEqual("Ruth.1.1")
-		expect(p.parse("Rut 1:1").osis()).toEqual("Ruth.1.1")
+		expect(p.parse("Ruth 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'Ruth 1:1'")
+		expect(p.parse("Rut 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'Rut 1:1'")
+		expect(p.parse("Ru 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'Ru 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("RUTH 1:1").osis()).toEqual("Ruth.1.1")
-		expect(p.parse("RUT 1:1").osis()).toEqual("Ruth.1.1")
+		expect(p.parse("RUTH 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'RUTH 1:1'")
+		expect(p.parse("RUT 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'RUT 1:1'")
+		expect(p.parse("RU 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'RU 1:1'")
 		`
 		true
 describe "Localized book 1Esd (de)", ->
@@ -426,16 +450,25 @@ describe "Localized book 1Esd (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Esd (de)", ->
 		`
-		expect(p.parse("Ersten Esra 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("Erstes Esra 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("Erste Esra 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1. Esra 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1 Esra 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1. Esr 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1 Esr 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1. Es 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1 Es 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1Esd 1:1").osis()).toEqual("1Esd.1.1")
+		expect(p.parse("Ersten Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Ersten Esdra 1:1'")
+		expect(p.parse("Erster Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erster Esdra 1:1'")
+		expect(p.parse("Erstes Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erstes Esdra 1:1'")
+		expect(p.parse("Erste Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erste Esdra 1:1'")
+		expect(p.parse("Ersten Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Ersten Esra 1:1'")
+		expect(p.parse("Erster Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erster Esra 1:1'")
+		expect(p.parse("Erstes Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erstes Esra 1:1'")
+		expect(p.parse("Erste Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erste Esra 1:1'")
+		expect(p.parse("1. Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Esdra 1:1'")
+		expect(p.parse("1 Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Esdra 1:1'")
+		expect(p.parse("1. Esdr 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Esdr 1:1'")
+		expect(p.parse("1. Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Esra 1:1'")
+		expect(p.parse("1 Esdr 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Esdr 1:1'")
+		expect(p.parse("1 Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Esra 1:1'")
+		expect(p.parse("1. Esr 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Esr 1:1'")
+		expect(p.parse("1 Esr 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Esr 1:1'")
+		expect(p.parse("1. Es 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Es 1:1'")
+		expect(p.parse("1 Es 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Es 1:1'")
+		expect(p.parse("1Esd 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1Esd 1:1'")
 		`
 		true
 describe "Localized book 2Esd (de)", ->
@@ -446,16 +479,25 @@ describe "Localized book 2Esd (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Esd (de)", ->
 		`
-		expect(p.parse("Zweiten Esra 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("Zweites Esra 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("Zweite Esra 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2. Esra 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2 Esra 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2. Esr 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2 Esr 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2. Es 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2 Es 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2Esd 1:1").osis()).toEqual("2Esd.1.1")
+		expect(p.parse("Zweiten Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweiten Esdra 1:1'")
+		expect(p.parse("Zweiter Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweiter Esdra 1:1'")
+		expect(p.parse("Zweites Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweites Esdra 1:1'")
+		expect(p.parse("Zweite Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweite Esdra 1:1'")
+		expect(p.parse("Zweiten Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweiten Esra 1:1'")
+		expect(p.parse("Zweiter Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweiter Esra 1:1'")
+		expect(p.parse("Zweites Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweites Esra 1:1'")
+		expect(p.parse("Zweite Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweite Esra 1:1'")
+		expect(p.parse("2. Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Esdra 1:1'")
+		expect(p.parse("2 Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Esdra 1:1'")
+		expect(p.parse("2. Esdr 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Esdr 1:1'")
+		expect(p.parse("2. Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Esra 1:1'")
+		expect(p.parse("2 Esdr 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Esdr 1:1'")
+		expect(p.parse("2 Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Esra 1:1'")
+		expect(p.parse("2. Esr 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Esr 1:1'")
+		expect(p.parse("2 Esr 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Esr 1:1'")
+		expect(p.parse("2. Es 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Es 1:1'")
+		expect(p.parse("2 Es 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Es 1:1'")
+		expect(p.parse("2Esd 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2Esd 1:1'")
 		`
 		true
 describe "Localized book Isa (de)", ->
@@ -466,15 +508,15 @@ describe "Localized book Isa (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Isa (de)", ->
 		`
-		expect(p.parse("Isaias 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("Jesaja 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("Isa 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("Jes 1:1").osis()).toEqual("Isa.1.1")
+		expect(p.parse("Isaias 1:1").osis()).toEqual("Isa.1.1", "parsing: 'Isaias 1:1'")
+		expect(p.parse("Jesaja 1:1").osis()).toEqual("Isa.1.1", "parsing: 'Jesaja 1:1'")
+		expect(p.parse("Isa 1:1").osis()).toEqual("Isa.1.1", "parsing: 'Isa 1:1'")
+		expect(p.parse("Jes 1:1").osis()).toEqual("Isa.1.1", "parsing: 'Jes 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ISAIAS 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("JESAJA 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("ISA 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("JES 1:1").osis()).toEqual("Isa.1.1")
+		expect(p.parse("ISAIAS 1:1").osis()).toEqual("Isa.1.1", "parsing: 'ISAIAS 1:1'")
+		expect(p.parse("JESAJA 1:1").osis()).toEqual("Isa.1.1", "parsing: 'JESAJA 1:1'")
+		expect(p.parse("ISA 1:1").osis()).toEqual("Isa.1.1", "parsing: 'ISA 1:1'")
+		expect(p.parse("JES 1:1").osis()).toEqual("Isa.1.1", "parsing: 'JES 1:1'")
 		`
 		true
 describe "Localized book 2Sam (de)", ->
@@ -485,23 +527,29 @@ describe "Localized book 2Sam (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Sam (de)", ->
 		`
-		expect(p.parse("Zweiten Samuel 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("Zweites Samuel 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("Zweite Samuel 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2. Samuel 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2 Samuel 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2. Sam 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2 Sam 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2Sam 1:1").osis()).toEqual("2Sam.1.1")
+		expect(p.parse("Zweiten Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'Zweiten Samuel 1:1'")
+		expect(p.parse("Zweiter Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'Zweiter Samuel 1:1'")
+		expect(p.parse("Zweites Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'Zweites Samuel 1:1'")
+		expect(p.parse("Zweite Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'Zweite Samuel 1:1'")
+		expect(p.parse("2. Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. Samuel 1:1'")
+		expect(p.parse("2 Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 Samuel 1:1'")
+		expect(p.parse("2. Sam 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. Sam 1:1'")
+		expect(p.parse("2 Sam 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 Sam 1:1'")
+		expect(p.parse("2. Sa 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. Sa 1:1'")
+		expect(p.parse("2 Sa 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 Sa 1:1'")
+		expect(p.parse("2Sam 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2Sam 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITEN SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("ZWEITES SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("ZWEITE SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2. SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2 SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2. SAM 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2 SAM 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2SAM 1:1").osis()).toEqual("2Sam.1.1")
+		expect(p.parse("ZWEITEN SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'ZWEITEN SAMUEL 1:1'")
+		expect(p.parse("ZWEITER SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'ZWEITER SAMUEL 1:1'")
+		expect(p.parse("ZWEITES SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'ZWEITES SAMUEL 1:1'")
+		expect(p.parse("ZWEITE SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'ZWEITE SAMUEL 1:1'")
+		expect(p.parse("2. SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. SAMUEL 1:1'")
+		expect(p.parse("2 SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 SAMUEL 1:1'")
+		expect(p.parse("2. SAM 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. SAM 1:1'")
+		expect(p.parse("2 SAM 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 SAM 1:1'")
+		expect(p.parse("2. SA 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. SA 1:1'")
+		expect(p.parse("2 SA 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 SA 1:1'")
+		expect(p.parse("2SAM 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2SAM 1:1'")
 		`
 		true
 describe "Localized book 1Sam (de)", ->
@@ -512,23 +560,29 @@ describe "Localized book 1Sam (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Sam (de)", ->
 		`
-		expect(p.parse("Ersten Samuel 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("Erstes Samuel 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("Erste Samuel 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1. Samuel 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1 Samuel 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1. Sam 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1 Sam 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1Sam 1:1").osis()).toEqual("1Sam.1.1")
+		expect(p.parse("Ersten Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'Ersten Samuel 1:1'")
+		expect(p.parse("Erster Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'Erster Samuel 1:1'")
+		expect(p.parse("Erstes Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'Erstes Samuel 1:1'")
+		expect(p.parse("Erste Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'Erste Samuel 1:1'")
+		expect(p.parse("1. Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. Samuel 1:1'")
+		expect(p.parse("1 Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 Samuel 1:1'")
+		expect(p.parse("1. Sam 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. Sam 1:1'")
+		expect(p.parse("1 Sam 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 Sam 1:1'")
+		expect(p.parse("1. Sa 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. Sa 1:1'")
+		expect(p.parse("1 Sa 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 Sa 1:1'")
+		expect(p.parse("1Sam 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1Sam 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTEN SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("ERSTES SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("ERSTE SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1. SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1 SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1. SAM 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1 SAM 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1SAM 1:1").osis()).toEqual("1Sam.1.1")
+		expect(p.parse("ERSTEN SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'ERSTEN SAMUEL 1:1'")
+		expect(p.parse("ERSTER SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'ERSTER SAMUEL 1:1'")
+		expect(p.parse("ERSTES SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'ERSTES SAMUEL 1:1'")
+		expect(p.parse("ERSTE SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'ERSTE SAMUEL 1:1'")
+		expect(p.parse("1. SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. SAMUEL 1:1'")
+		expect(p.parse("1 SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 SAMUEL 1:1'")
+		expect(p.parse("1. SAM 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. SAM 1:1'")
+		expect(p.parse("1 SAM 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 SAM 1:1'")
+		expect(p.parse("1. SA 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. SA 1:1'")
+		expect(p.parse("1 SA 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 SA 1:1'")
+		expect(p.parse("1SAM 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1SAM 1:1'")
 		`
 		true
 describe "Localized book 2Kgs (de)", ->
@@ -539,34 +593,73 @@ describe "Localized book 2Kgs (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Kgs (de)", ->
 		`
-		expect(p.parse("Zweiten Könige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("Zweites Könige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("Zweite Könige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Koenige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Koenige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Könige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Könige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Kon 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Kön 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Kon 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Kön 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2Kgs 1:1").osis()).toEqual("2Kgs.1.1")
+		expect(p.parse("Zweiten Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiten Koenige 1:1'")
+		expect(p.parse("Zweiter Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiter Koenige 1:1'")
+		expect(p.parse("Zweites Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweites Koenige 1:1'")
+		expect(p.parse("Zweite Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweite Koenige 1:1'")
+		expect(p.parse("Zweiten Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiten Konige 1:1'")
+		expect(p.parse("Zweiten Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiten Könige 1:1'")
+		expect(p.parse("Zweiter Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiter Konige 1:1'")
+		expect(p.parse("Zweiter Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiter Könige 1:1'")
+		expect(p.parse("Zweites Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweites Konige 1:1'")
+		expect(p.parse("Zweites Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweites Könige 1:1'")
+		expect(p.parse("Zweite Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweite Konige 1:1'")
+		expect(p.parse("Zweite Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweite Könige 1:1'")
+		expect(p.parse("2. Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Koenige 1:1'")
+		expect(p.parse("2 Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Koenige 1:1'")
+		expect(p.parse("2. Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Konige 1:1'")
+		expect(p.parse("2. Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Könige 1:1'")
+		expect(p.parse("2 Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Konige 1:1'")
+		expect(p.parse("2 Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Könige 1:1'")
+		expect(p.parse("2. Koen 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Koen 1:1'")
+		expect(p.parse("2 Koen 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Koen 1:1'")
+		expect(p.parse("2. Kng 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Kng 1:1'")
+		expect(p.parse("2. Koe 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Koe 1:1'")
+		expect(p.parse("2. Kon 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Kon 1:1'")
+		expect(p.parse("2. Kön 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Kön 1:1'")
+		expect(p.parse("2 Kng 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Kng 1:1'")
+		expect(p.parse("2 Koe 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Koe 1:1'")
+		expect(p.parse("2 Kon 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Kon 1:1'")
+		expect(p.parse("2 Kön 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Kön 1:1'")
+		expect(p.parse("2. Ko 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Ko 1:1'")
+		expect(p.parse("2. Kö 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Kö 1:1'")
+		expect(p.parse("2 Ko 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Ko 1:1'")
+		expect(p.parse("2 Kö 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Kö 1:1'")
+		expect(p.parse("2Kgs 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2Kgs 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITEN KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("ZWEITES KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("ZWEITE KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("ZWEITEN KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("ZWEITES KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("ZWEITE KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KON 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KÖN 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KON 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KÖN 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2KGS 1:1").osis()).toEqual("2Kgs.1.1")
+		expect(p.parse("ZWEITEN KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITEN KOENIGE 1:1'")
+		expect(p.parse("ZWEITER KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITER KOENIGE 1:1'")
+		expect(p.parse("ZWEITES KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITES KOENIGE 1:1'")
+		expect(p.parse("ZWEITE KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITE KOENIGE 1:1'")
+		expect(p.parse("ZWEITEN KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITEN KONIGE 1:1'")
+		expect(p.parse("ZWEITEN KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITEN KÖNIGE 1:1'")
+		expect(p.parse("ZWEITER KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITER KONIGE 1:1'")
+		expect(p.parse("ZWEITER KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITER KÖNIGE 1:1'")
+		expect(p.parse("ZWEITES KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITES KONIGE 1:1'")
+		expect(p.parse("ZWEITES KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITES KÖNIGE 1:1'")
+		expect(p.parse("ZWEITE KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITE KONIGE 1:1'")
+		expect(p.parse("ZWEITE KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITE KÖNIGE 1:1'")
+		expect(p.parse("2. KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KOENIGE 1:1'")
+		expect(p.parse("2 KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KOENIGE 1:1'")
+		expect(p.parse("2. KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KONIGE 1:1'")
+		expect(p.parse("2. KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KÖNIGE 1:1'")
+		expect(p.parse("2 KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KONIGE 1:1'")
+		expect(p.parse("2 KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KÖNIGE 1:1'")
+		expect(p.parse("2. KOEN 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KOEN 1:1'")
+		expect(p.parse("2 KOEN 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KOEN 1:1'")
+		expect(p.parse("2. KNG 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KNG 1:1'")
+		expect(p.parse("2. KOE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KOE 1:1'")
+		expect(p.parse("2. KON 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KON 1:1'")
+		expect(p.parse("2. KÖN 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KÖN 1:1'")
+		expect(p.parse("2 KNG 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KNG 1:1'")
+		expect(p.parse("2 KOE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KOE 1:1'")
+		expect(p.parse("2 KON 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KON 1:1'")
+		expect(p.parse("2 KÖN 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KÖN 1:1'")
+		expect(p.parse("2. KO 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KO 1:1'")
+		expect(p.parse("2. KÖ 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KÖ 1:1'")
+		expect(p.parse("2 KO 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KO 1:1'")
+		expect(p.parse("2 KÖ 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KÖ 1:1'")
+		expect(p.parse("2KGS 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2KGS 1:1'")
 		`
 		true
 describe "Localized book 1Kgs (de)", ->
@@ -577,36 +670,73 @@ describe "Localized book 1Kgs (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Kgs (de)", ->
 		`
-		expect(p.parse("Ersten Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("Erstes Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("Erste Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("Ersten Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("Erstes Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("Erste Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Kön 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Kon 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Kön 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1Kgs 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("Ersten Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Ersten Koenige 1:1'")
+		expect(p.parse("Erster Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erster Koenige 1:1'")
+		expect(p.parse("Erstes Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erstes Koenige 1:1'")
+		expect(p.parse("Erste Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erste Koenige 1:1'")
+		expect(p.parse("Ersten Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Ersten Konige 1:1'")
+		expect(p.parse("Ersten Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Ersten Könige 1:1'")
+		expect(p.parse("Erster Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erster Konige 1:1'")
+		expect(p.parse("Erster Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erster Könige 1:1'")
+		expect(p.parse("Erstes Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erstes Konige 1:1'")
+		expect(p.parse("Erstes Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erstes Könige 1:1'")
+		expect(p.parse("Erste Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erste Konige 1:1'")
+		expect(p.parse("Erste Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erste Könige 1:1'")
+		expect(p.parse("1. Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Koenige 1:1'")
+		expect(p.parse("1 Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Koenige 1:1'")
+		expect(p.parse("1. Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Konige 1:1'")
+		expect(p.parse("1. Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Könige 1:1'")
+		expect(p.parse("1 Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Konige 1:1'")
+		expect(p.parse("1 Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Könige 1:1'")
+		expect(p.parse("1. Koen 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Koen 1:1'")
+		expect(p.parse("1 Koen 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Koen 1:1'")
+		expect(p.parse("1. Kng 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Kng 1:1'")
+		expect(p.parse("1. Koe 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Koe 1:1'")
+		expect(p.parse("1. Kon 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Kon 1:1'")
+		expect(p.parse("1. Kön 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Kön 1:1'")
+		expect(p.parse("1 Kng 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Kng 1:1'")
+		expect(p.parse("1 Koe 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Koe 1:1'")
+		expect(p.parse("1 Kon 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Kon 1:1'")
+		expect(p.parse("1 Kön 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Kön 1:1'")
+		expect(p.parse("1. Ko 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Ko 1:1'")
+		expect(p.parse("1. Kö 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Kö 1:1'")
+		expect(p.parse("1 Ko 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Ko 1:1'")
+		expect(p.parse("1 Kö 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Kö 1:1'")
+		expect(p.parse("1Kgs 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1Kgs 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTEN KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("ERSTES KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("ERSTE KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("ERSTEN KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("ERSTES KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("ERSTE KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KON 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KÖN 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KON 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KÖN 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1KGS 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("ERSTEN KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTEN KOENIGE 1:1'")
+		expect(p.parse("ERSTER KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTER KOENIGE 1:1'")
+		expect(p.parse("ERSTES KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTES KOENIGE 1:1'")
+		expect(p.parse("ERSTE KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTE KOENIGE 1:1'")
+		expect(p.parse("ERSTEN KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTEN KONIGE 1:1'")
+		expect(p.parse("ERSTEN KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTEN KÖNIGE 1:1'")
+		expect(p.parse("ERSTER KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTER KONIGE 1:1'")
+		expect(p.parse("ERSTER KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTER KÖNIGE 1:1'")
+		expect(p.parse("ERSTES KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTES KONIGE 1:1'")
+		expect(p.parse("ERSTES KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTES KÖNIGE 1:1'")
+		expect(p.parse("ERSTE KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTE KONIGE 1:1'")
+		expect(p.parse("ERSTE KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTE KÖNIGE 1:1'")
+		expect(p.parse("1. KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KOENIGE 1:1'")
+		expect(p.parse("1 KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KOENIGE 1:1'")
+		expect(p.parse("1. KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KONIGE 1:1'")
+		expect(p.parse("1. KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KÖNIGE 1:1'")
+		expect(p.parse("1 KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KONIGE 1:1'")
+		expect(p.parse("1 KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KÖNIGE 1:1'")
+		expect(p.parse("1. KOEN 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KOEN 1:1'")
+		expect(p.parse("1 KOEN 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KOEN 1:1'")
+		expect(p.parse("1. KNG 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KNG 1:1'")
+		expect(p.parse("1. KOE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KOE 1:1'")
+		expect(p.parse("1. KON 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KON 1:1'")
+		expect(p.parse("1. KÖN 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KÖN 1:1'")
+		expect(p.parse("1 KNG 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KNG 1:1'")
+		expect(p.parse("1 KOE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KOE 1:1'")
+		expect(p.parse("1 KON 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KON 1:1'")
+		expect(p.parse("1 KÖN 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KÖN 1:1'")
+		expect(p.parse("1. KO 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KO 1:1'")
+		expect(p.parse("1. KÖ 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KÖ 1:1'")
+		expect(p.parse("1 KO 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KO 1:1'")
+		expect(p.parse("1 KÖ 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KÖ 1:1'")
+		expect(p.parse("1KGS 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1KGS 1:1'")
 		`
 		true
 describe "Localized book 2Chr (de)", ->
@@ -617,23 +747,29 @@ describe "Localized book 2Chr (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Chr (de)", ->
 		`
-		expect(p.parse("Zweiten Chronik 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("Zweites Chronik 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("Zweite Chronik 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2. Chronik 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2 Chronik 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2. Chr 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2 Chr 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2Chr 1:1").osis()).toEqual("2Chr.1.1")
+		expect(p.parse("Zweiten Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'Zweiten Chronik 1:1'")
+		expect(p.parse("Zweiter Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'Zweiter Chronik 1:1'")
+		expect(p.parse("Zweites Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'Zweites Chronik 1:1'")
+		expect(p.parse("Zweite Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'Zweite Chronik 1:1'")
+		expect(p.parse("2. Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. Chronik 1:1'")
+		expect(p.parse("2 Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 Chronik 1:1'")
+		expect(p.parse("2. Chron 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. Chron 1:1'")
+		expect(p.parse("2 Chron 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 Chron 1:1'")
+		expect(p.parse("2. Chr 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. Chr 1:1'")
+		expect(p.parse("2 Chr 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 Chr 1:1'")
+		expect(p.parse("2Chr 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2Chr 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITEN CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("ZWEITES CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("ZWEITE CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2. CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2 CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2. CHR 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2 CHR 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2CHR 1:1").osis()).toEqual("2Chr.1.1")
+		expect(p.parse("ZWEITEN CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'ZWEITEN CHRONIK 1:1'")
+		expect(p.parse("ZWEITER CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'ZWEITER CHRONIK 1:1'")
+		expect(p.parse("ZWEITES CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'ZWEITES CHRONIK 1:1'")
+		expect(p.parse("ZWEITE CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'ZWEITE CHRONIK 1:1'")
+		expect(p.parse("2. CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. CHRONIK 1:1'")
+		expect(p.parse("2 CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 CHRONIK 1:1'")
+		expect(p.parse("2. CHRON 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. CHRON 1:1'")
+		expect(p.parse("2 CHRON 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 CHRON 1:1'")
+		expect(p.parse("2. CHR 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. CHR 1:1'")
+		expect(p.parse("2 CHR 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 CHR 1:1'")
+		expect(p.parse("2CHR 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2CHR 1:1'")
 		`
 		true
 describe "Localized book 1Chr (de)", ->
@@ -644,23 +780,29 @@ describe "Localized book 1Chr (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Chr (de)", ->
 		`
-		expect(p.parse("Ersten Chronik 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("Erstes Chronik 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("Erste Chronik 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1. Chronik 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1 Chronik 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1. Chr 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1 Chr 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1Chr 1:1").osis()).toEqual("1Chr.1.1")
+		expect(p.parse("Ersten Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'Ersten Chronik 1:1'")
+		expect(p.parse("Erster Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'Erster Chronik 1:1'")
+		expect(p.parse("Erstes Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'Erstes Chronik 1:1'")
+		expect(p.parse("Erste Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'Erste Chronik 1:1'")
+		expect(p.parse("1. Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. Chronik 1:1'")
+		expect(p.parse("1 Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 Chronik 1:1'")
+		expect(p.parse("1. Chron 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. Chron 1:1'")
+		expect(p.parse("1 Chron 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 Chron 1:1'")
+		expect(p.parse("1. Chr 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. Chr 1:1'")
+		expect(p.parse("1 Chr 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 Chr 1:1'")
+		expect(p.parse("1Chr 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1Chr 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTEN CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("ERSTES CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("ERSTE CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1. CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1 CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1. CHR 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1 CHR 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1CHR 1:1").osis()).toEqual("1Chr.1.1")
+		expect(p.parse("ERSTEN CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'ERSTEN CHRONIK 1:1'")
+		expect(p.parse("ERSTER CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'ERSTER CHRONIK 1:1'")
+		expect(p.parse("ERSTES CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'ERSTES CHRONIK 1:1'")
+		expect(p.parse("ERSTE CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'ERSTE CHRONIK 1:1'")
+		expect(p.parse("1. CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. CHRONIK 1:1'")
+		expect(p.parse("1 CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 CHRONIK 1:1'")
+		expect(p.parse("1. CHRON 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. CHRON 1:1'")
+		expect(p.parse("1 CHRON 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 CHRON 1:1'")
+		expect(p.parse("1. CHR 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. CHR 1:1'")
+		expect(p.parse("1 CHR 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 CHR 1:1'")
+		expect(p.parse("1CHR 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1CHR 1:1'")
 		`
 		true
 describe "Localized book Ezra (de)", ->
@@ -671,13 +813,13 @@ describe "Localized book Ezra (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Ezra (de)", ->
 		`
-		expect(p.parse("Esra 1:1").osis()).toEqual("Ezra.1.1")
-		expect(p.parse("Ezra 1:1").osis()).toEqual("Ezra.1.1")
-		expect(p.parse("Esr 1:1").osis()).toEqual("Ezra.1.1")
+		expect(p.parse("Esra 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'Esra 1:1'")
+		expect(p.parse("Ezra 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'Ezra 1:1'")
+		expect(p.parse("Esr 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'Esr 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ESRA 1:1").osis()).toEqual("Ezra.1.1")
-		expect(p.parse("EZRA 1:1").osis()).toEqual("Ezra.1.1")
-		expect(p.parse("ESR 1:1").osis()).toEqual("Ezra.1.1")
+		expect(p.parse("ESRA 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'ESRA 1:1'")
+		expect(p.parse("EZRA 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'EZRA 1:1'")
+		expect(p.parse("ESR 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'ESR 1:1'")
 		`
 		true
 describe "Localized book Neh (de)", ->
@@ -688,11 +830,11 @@ describe "Localized book Neh (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Neh (de)", ->
 		`
-		expect(p.parse("Nehemia 1:1").osis()).toEqual("Neh.1.1")
-		expect(p.parse("Neh 1:1").osis()).toEqual("Neh.1.1")
+		expect(p.parse("Nehemia 1:1").osis()).toEqual("Neh.1.1", "parsing: 'Nehemia 1:1'")
+		expect(p.parse("Neh 1:1").osis()).toEqual("Neh.1.1", "parsing: 'Neh 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("NEHEMIA 1:1").osis()).toEqual("Neh.1.1")
-		expect(p.parse("NEH 1:1").osis()).toEqual("Neh.1.1")
+		expect(p.parse("NEHEMIA 1:1").osis()).toEqual("Neh.1.1", "parsing: 'NEHEMIA 1:1'")
+		expect(p.parse("NEH 1:1").osis()).toEqual("Neh.1.1", "parsing: 'NEH 1:1'")
 		`
 		true
 describe "Localized book GkEsth (de)", ->
@@ -703,10 +845,10 @@ describe "Localized book GkEsth (de)", ->
 		p.include_apocrypha true
 	it "should handle book: GkEsth (de)", ->
 		`
-		expect(p.parse("Ester \(Griechisch\) 1:1").osis()).toEqual("GkEsth.1.1")
-		expect(p.parse("Ester (Griechisch) 1:1").osis()).toEqual("GkEsth.1.1")
-		expect(p.parse("GkEsth 1:1").osis()).toEqual("GkEsth.1.1")
-		expect(p.parse("Gr Est 1:1").osis()).toEqual("GkEsth.1.1")
+		expect(p.parse("Ester \(Griechisch\) 1:1").osis()).toEqual("GkEsth.1.1", "parsing: 'Ester \(Griechisch\) 1:1'")
+		expect(p.parse("Ester (Griechisch) 1:1").osis()).toEqual("GkEsth.1.1", "parsing: 'Ester (Griechisch) 1:1'")
+		expect(p.parse("GkEsth 1:1").osis()).toEqual("GkEsth.1.1", "parsing: 'GkEsth 1:1'")
+		expect(p.parse("Gr Est 1:1").osis()).toEqual("GkEsth.1.1", "parsing: 'Gr Est 1:1'")
 		`
 		true
 describe "Localized book Esth (de)", ->
@@ -717,15 +859,15 @@ describe "Localized book Esth (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Esth (de)", ->
 		`
-		expect(p.parse("Esther 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("Ester 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("Esth 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("Est 1:1").osis()).toEqual("Esth.1.1")
+		expect(p.parse("Esther 1:1").osis()).toEqual("Esth.1.1", "parsing: 'Esther 1:1'")
+		expect(p.parse("Ester 1:1").osis()).toEqual("Esth.1.1", "parsing: 'Ester 1:1'")
+		expect(p.parse("Esth 1:1").osis()).toEqual("Esth.1.1", "parsing: 'Esth 1:1'")
+		expect(p.parse("Est 1:1").osis()).toEqual("Esth.1.1", "parsing: 'Est 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ESTHER 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("ESTER 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("ESTH 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("EST 1:1").osis()).toEqual("Esth.1.1")
+		expect(p.parse("ESTHER 1:1").osis()).toEqual("Esth.1.1", "parsing: 'ESTHER 1:1'")
+		expect(p.parse("ESTER 1:1").osis()).toEqual("Esth.1.1", "parsing: 'ESTER 1:1'")
+		expect(p.parse("ESTH 1:1").osis()).toEqual("Esth.1.1", "parsing: 'ESTH 1:1'")
+		expect(p.parse("EST 1:1").osis()).toEqual("Esth.1.1", "parsing: 'EST 1:1'")
 		`
 		true
 describe "Localized book Job (de)", ->
@@ -736,15 +878,15 @@ describe "Localized book Job (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Job (de)", ->
 		`
-		expect(p.parse("Hiob 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("Ijob 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("Job 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("Hi 1:1").osis()).toEqual("Job.1.1")
+		expect(p.parse("Hiob 1:1").osis()).toEqual("Job.1.1", "parsing: 'Hiob 1:1'")
+		expect(p.parse("Ijob 1:1").osis()).toEqual("Job.1.1", "parsing: 'Ijob 1:1'")
+		expect(p.parse("Job 1:1").osis()).toEqual("Job.1.1", "parsing: 'Job 1:1'")
+		expect(p.parse("Hi 1:1").osis()).toEqual("Job.1.1", "parsing: 'Hi 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HIOB 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("IJOB 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("JOB 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("HI 1:1").osis()).toEqual("Job.1.1")
+		expect(p.parse("HIOB 1:1").osis()).toEqual("Job.1.1", "parsing: 'HIOB 1:1'")
+		expect(p.parse("IJOB 1:1").osis()).toEqual("Job.1.1", "parsing: 'IJOB 1:1'")
+		expect(p.parse("JOB 1:1").osis()).toEqual("Job.1.1", "parsing: 'JOB 1:1'")
+		expect(p.parse("HI 1:1").osis()).toEqual("Job.1.1", "parsing: 'HI 1:1'")
 		`
 		true
 describe "Localized book Ps (de)", ->
@@ -755,13 +897,15 @@ describe "Localized book Ps (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Ps (de)", ->
 		`
-		expect(p.parse("Psalmen 1:1").osis()).toEqual("Ps.1.1")
-		expect(p.parse("Psalm 1:1").osis()).toEqual("Ps.1.1")
-		expect(p.parse("Ps 1:1").osis()).toEqual("Ps.1.1")
+		expect(p.parse("Psalmen 1:1").osis()).toEqual("Ps.1.1", "parsing: 'Psalmen 1:1'")
+		expect(p.parse("Psalm 1:1").osis()).toEqual("Ps.1.1", "parsing: 'Psalm 1:1'")
+		expect(p.parse("Pslm 1:1").osis()).toEqual("Ps.1.1", "parsing: 'Pslm 1:1'")
+		expect(p.parse("Ps 1:1").osis()).toEqual("Ps.1.1", "parsing: 'Ps 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("PSALMEN 1:1").osis()).toEqual("Ps.1.1")
-		expect(p.parse("PSALM 1:1").osis()).toEqual("Ps.1.1")
-		expect(p.parse("PS 1:1").osis()).toEqual("Ps.1.1")
+		expect(p.parse("PSALMEN 1:1").osis()).toEqual("Ps.1.1", "parsing: 'PSALMEN 1:1'")
+		expect(p.parse("PSALM 1:1").osis()).toEqual("Ps.1.1", "parsing: 'PSALM 1:1'")
+		expect(p.parse("PSLM 1:1").osis()).toEqual("Ps.1.1", "parsing: 'PSLM 1:1'")
+		expect(p.parse("PS 1:1").osis()).toEqual("Ps.1.1", "parsing: 'PS 1:1'")
 		`
 		true
 describe "Localized book PrAzar (de)", ->
@@ -772,9 +916,12 @@ describe "Localized book PrAzar (de)", ->
 		p.include_apocrypha true
 	it "should handle book: PrAzar (de)", ->
 		`
-		expect(p.parse("Gebet des Asarja 1:1").osis()).toEqual("PrAzar.1.1")
-		expect(p.parse("Geb As 1:1").osis()).toEqual("PrAzar.1.1")
-		expect(p.parse("PrAzar 1:1").osis()).toEqual("PrAzar.1.1")
+		expect(p.parse("Das Gebet des Asarja 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Das Gebet des Asarja 1:1'")
+		expect(p.parse("Das Gebet Asarjas 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Das Gebet Asarjas 1:1'")
+		expect(p.parse("Gebet des Asarja 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Gebet des Asarja 1:1'")
+		expect(p.parse("Gebet Asarjas 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Gebet Asarjas 1:1'")
+		expect(p.parse("Geb As 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Geb As 1:1'")
+		expect(p.parse("PrAzar 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'PrAzar 1:1'")
 		`
 		true
 describe "Localized book Prov (de)", ->
@@ -785,19 +932,23 @@ describe "Localized book Prov (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Prov (de)", ->
 		`
-		expect(p.parse("Sprichwoerter 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Sprichwörter 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Sprueche 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Sprüche 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Prov 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Spr 1:1").osis()).toEqual("Prov.1.1")
+		expect(p.parse("Sprichwoerter 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprichwoerter 1:1'")
+		expect(p.parse("Sprichworter 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprichworter 1:1'")
+		expect(p.parse("Sprichwörter 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprichwörter 1:1'")
+		expect(p.parse("Sprueche 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprueche 1:1'")
+		expect(p.parse("Spruche 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Spruche 1:1'")
+		expect(p.parse("Sprüche 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprüche 1:1'")
+		expect(p.parse("Prov 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Prov 1:1'")
+		expect(p.parse("Spr 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Spr 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("SPRICHWOERTER 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPRICHWÖRTER 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPRUECHE 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPRÜCHE 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("PROV 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPR 1:1").osis()).toEqual("Prov.1.1")
+		expect(p.parse("SPRICHWOERTER 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRICHWOERTER 1:1'")
+		expect(p.parse("SPRICHWORTER 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRICHWORTER 1:1'")
+		expect(p.parse("SPRICHWÖRTER 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRICHWÖRTER 1:1'")
+		expect(p.parse("SPRUECHE 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRUECHE 1:1'")
+		expect(p.parse("SPRUCHE 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRUCHE 1:1'")
+		expect(p.parse("SPRÜCHE 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRÜCHE 1:1'")
+		expect(p.parse("PROV 1:1").osis()).toEqual("Prov.1.1", "parsing: 'PROV 1:1'")
+		expect(p.parse("SPR 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPR 1:1'")
 		`
 		true
 describe "Localized book Eccl (de)", ->
@@ -808,21 +959,21 @@ describe "Localized book Eccl (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Eccl (de)", ->
 		`
-		expect(p.parse("Ecclesiastes 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Ekklesiastes 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Prediger 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Kohelet 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Eccl 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Pred 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Koh 1:1").osis()).toEqual("Eccl.1.1")
+		expect(p.parse("Ecclesiastes 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Ecclesiastes 1:1'")
+		expect(p.parse("Ekklesiastes 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Ekklesiastes 1:1'")
+		expect(p.parse("Prediger 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Prediger 1:1'")
+		expect(p.parse("Kohelet 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Kohelet 1:1'")
+		expect(p.parse("Eccl 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Eccl 1:1'")
+		expect(p.parse("Pred 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Pred 1:1'")
+		expect(p.parse("Koh 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Koh 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ECCLESIASTES 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("EKKLESIASTES 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("PREDIGER 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("KOHELET 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("ECCL 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("PRED 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("KOH 1:1").osis()).toEqual("Eccl.1.1")
+		expect(p.parse("ECCLESIASTES 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'ECCLESIASTES 1:1'")
+		expect(p.parse("EKKLESIASTES 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'EKKLESIASTES 1:1'")
+		expect(p.parse("PREDIGER 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'PREDIGER 1:1'")
+		expect(p.parse("KOHELET 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'KOHELET 1:1'")
+		expect(p.parse("ECCL 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'ECCL 1:1'")
+		expect(p.parse("PRED 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'PRED 1:1'")
+		expect(p.parse("KOH 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'KOH 1:1'")
 		`
 		true
 describe "Localized book SgThree (de)", ->
@@ -833,18 +984,17 @@ describe "Localized book SgThree (de)", ->
 		p.include_apocrypha true
 	it "should handle book: SgThree (de)", ->
 		`
-		expect(p.parse("Lobgesang der drei jungen Männer im Feuerofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der drei jungen Männer im Feuerofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Der Gesang der Drei Männer im feurigen Ofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Der Gesang der Drei Männer im feurigen Ofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der drei jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der drei jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der 3 jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der 3 jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Der Gesang der Drei 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Gesang der Drei 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("SgThree 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("L3J 1:1").osis()).toEqual("SgThree.1.1")
+		expect(p.parse("Gesang der drei Maenner im Feuerofen 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Maenner im Feuerofen 1:1'")
+		expect(p.parse("Gesang der drei Manner im Feuerofen 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Manner im Feuerofen 1:1'")
+		expect(p.parse("Gesang der drei Männer im Feuerofen 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Männer im Feuerofen 1:1'")
+		expect(p.parse("Gesang der drei im Feuerofen 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei im Feuerofen 1:1'")
+		expect(p.parse("Gesang der drei Maenner 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Maenner 1:1'")
+		expect(p.parse("Gesang der drei Manner 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Manner 1:1'")
+		expect(p.parse("Gesang der drei Männer 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Männer 1:1'")
+		expect(p.parse("Gesang der Drei 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der Drei 1:1'")
+		expect(p.parse("Gesang der drei 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei 1:1'")
+		expect(p.parse("SgThree 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'SgThree 1:1'")
+		expect(p.parse("L3J 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'L3J 1:1'")
 		`
 		true
 describe "Localized book Song (de)", ->
@@ -855,21 +1005,25 @@ describe "Localized book Song (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Song (de)", ->
 		`
-		expect(p.parse("Hohelied Salomonis 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hoheslied Salomos 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hohes Lied 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hoheslied 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hohelied 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Song 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hld 1:1").osis()).toEqual("Song.1.1")
+		expect(p.parse("Hoheslied Salomonis 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hoheslied Salomonis 1:1'")
+		expect(p.parse("Hohelied Salomonis 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hohelied Salomonis 1:1'")
+		expect(p.parse("Hoheslied Salomos 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hoheslied Salomos 1:1'")
+		expect(p.parse("Hohelied Salomos 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hohelied Salomos 1:1'")
+		expect(p.parse("Hohes Lied 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hohes Lied 1:1'")
+		expect(p.parse("Hoheslied 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hoheslied 1:1'")
+		expect(p.parse("Hohelied 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hohelied 1:1'")
+		expect(p.parse("Song 1:1").osis()).toEqual("Song.1.1", "parsing: 'Song 1:1'")
+		expect(p.parse("Hld 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hld 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HOHELIED SALOMONIS 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HOHESLIED SALOMOS 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HOHES LIED 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HOHESLIED 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HOHELIED 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("SONG 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HLD 1:1").osis()).toEqual("Song.1.1")
+		expect(p.parse("HOHESLIED SALOMONIS 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHESLIED SALOMONIS 1:1'")
+		expect(p.parse("HOHELIED SALOMONIS 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHELIED SALOMONIS 1:1'")
+		expect(p.parse("HOHESLIED SALOMOS 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHESLIED SALOMOS 1:1'")
+		expect(p.parse("HOHELIED SALOMOS 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHELIED SALOMOS 1:1'")
+		expect(p.parse("HOHES LIED 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHES LIED 1:1'")
+		expect(p.parse("HOHESLIED 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHESLIED 1:1'")
+		expect(p.parse("HOHELIED 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHELIED 1:1'")
+		expect(p.parse("SONG 1:1").osis()).toEqual("Song.1.1", "parsing: 'SONG 1:1'")
+		expect(p.parse("HLD 1:1").osis()).toEqual("Song.1.1", "parsing: 'HLD 1:1'")
 		`
 		true
 describe "Localized book Jer (de)", ->
@@ -880,13 +1034,13 @@ describe "Localized book Jer (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Jer (de)", ->
 		`
-		expect(p.parse("Jeremias 1:1").osis()).toEqual("Jer.1.1")
-		expect(p.parse("Jeremia 1:1").osis()).toEqual("Jer.1.1")
-		expect(p.parse("Jer 1:1").osis()).toEqual("Jer.1.1")
+		expect(p.parse("Jeremias 1:1").osis()).toEqual("Jer.1.1", "parsing: 'Jeremias 1:1'")
+		expect(p.parse("Jeremia 1:1").osis()).toEqual("Jer.1.1", "parsing: 'Jeremia 1:1'")
+		expect(p.parse("Jer 1:1").osis()).toEqual("Jer.1.1", "parsing: 'Jer 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JEREMIAS 1:1").osis()).toEqual("Jer.1.1")
-		expect(p.parse("JEREMIA 1:1").osis()).toEqual("Jer.1.1")
-		expect(p.parse("JER 1:1").osis()).toEqual("Jer.1.1")
+		expect(p.parse("JEREMIAS 1:1").osis()).toEqual("Jer.1.1", "parsing: 'JEREMIAS 1:1'")
+		expect(p.parse("JEREMIA 1:1").osis()).toEqual("Jer.1.1", "parsing: 'JEREMIA 1:1'")
+		expect(p.parse("JER 1:1").osis()).toEqual("Jer.1.1", "parsing: 'JER 1:1'")
 		`
 		true
 describe "Localized book Ezek (de)", ->
@@ -897,17 +1051,19 @@ describe "Localized book Ezek (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Ezek (de)", ->
 		`
-		expect(p.parse("Ezechiel 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("Hesekiel 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("Ezek 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("Hes 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("Ez 1:1").osis()).toEqual("Ezek.1.1")
+		expect(p.parse("Ezechiel 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Ezechiel 1:1'")
+		expect(p.parse("Hesekiel 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Hesekiel 1:1'")
+		expect(p.parse("Hesek 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Hesek 1:1'")
+		expect(p.parse("Ezek 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Ezek 1:1'")
+		expect(p.parse("Hes 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Hes 1:1'")
+		expect(p.parse("Ez 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Ez 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("EZECHIEL 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("HESEKIEL 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("EZEK 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("HES 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("EZ 1:1").osis()).toEqual("Ezek.1.1")
+		expect(p.parse("EZECHIEL 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'EZECHIEL 1:1'")
+		expect(p.parse("HESEKIEL 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'HESEKIEL 1:1'")
+		expect(p.parse("HESEK 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'HESEK 1:1'")
+		expect(p.parse("EZEK 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'EZEK 1:1'")
+		expect(p.parse("HES 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'HES 1:1'")
+		expect(p.parse("EZ 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'EZ 1:1'")
 		`
 		true
 describe "Localized book Dan (de)", ->
@@ -918,11 +1074,11 @@ describe "Localized book Dan (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Dan (de)", ->
 		`
-		expect(p.parse("Daniel 1:1").osis()).toEqual("Dan.1.1")
-		expect(p.parse("Dan 1:1").osis()).toEqual("Dan.1.1")
+		expect(p.parse("Daniel 1:1").osis()).toEqual("Dan.1.1", "parsing: 'Daniel 1:1'")
+		expect(p.parse("Dan 1:1").osis()).toEqual("Dan.1.1", "parsing: 'Dan 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DANIEL 1:1").osis()).toEqual("Dan.1.1")
-		expect(p.parse("DAN 1:1").osis()).toEqual("Dan.1.1")
+		expect(p.parse("DANIEL 1:1").osis()).toEqual("Dan.1.1", "parsing: 'DANIEL 1:1'")
+		expect(p.parse("DAN 1:1").osis()).toEqual("Dan.1.1", "parsing: 'DAN 1:1'")
 		`
 		true
 describe "Localized book Hos (de)", ->
@@ -933,13 +1089,11 @@ describe "Localized book Hos (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Hos (de)", ->
 		`
-		expect(p.parse("Hosea 1:1").osis()).toEqual("Hos.1.1")
-		expect(p.parse("Osee 1:1").osis()).toEqual("Hos.1.1")
-		expect(p.parse("Hos 1:1").osis()).toEqual("Hos.1.1")
+		expect(p.parse("Hosea 1:1").osis()).toEqual("Hos.1.1", "parsing: 'Hosea 1:1'")
+		expect(p.parse("Hos 1:1").osis()).toEqual("Hos.1.1", "parsing: 'Hos 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HOSEA 1:1").osis()).toEqual("Hos.1.1")
-		expect(p.parse("OSEE 1:1").osis()).toEqual("Hos.1.1")
-		expect(p.parse("HOS 1:1").osis()).toEqual("Hos.1.1")
+		expect(p.parse("HOSEA 1:1").osis()).toEqual("Hos.1.1", "parsing: 'HOSEA 1:1'")
+		expect(p.parse("HOS 1:1").osis()).toEqual("Hos.1.1", "parsing: 'HOS 1:1'")
 		`
 		true
 describe "Localized book Joel (de)", ->
@@ -950,9 +1104,9 @@ describe "Localized book Joel (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Joel (de)", ->
 		`
-		expect(p.parse("Joel 1:1").osis()).toEqual("Joel.1.1")
+		expect(p.parse("Joel 1:1").osis()).toEqual("Joel.1.1", "parsing: 'Joel 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JOEL 1:1").osis()).toEqual("Joel.1.1")
+		expect(p.parse("JOEL 1:1").osis()).toEqual("Joel.1.1", "parsing: 'JOEL 1:1'")
 		`
 		true
 describe "Localized book Amos (de)", ->
@@ -963,11 +1117,11 @@ describe "Localized book Amos (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Amos (de)", ->
 		`
-		expect(p.parse("Amos 1:1").osis()).toEqual("Amos.1.1")
-		expect(p.parse("Am 1:1").osis()).toEqual("Amos.1.1")
+		expect(p.parse("Amos 1:1").osis()).toEqual("Amos.1.1", "parsing: 'Amos 1:1'")
+		expect(p.parse("Am 1:1").osis()).toEqual("Amos.1.1", "parsing: 'Am 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("AMOS 1:1").osis()).toEqual("Amos.1.1")
-		expect(p.parse("AM 1:1").osis()).toEqual("Amos.1.1")
+		expect(p.parse("AMOS 1:1").osis()).toEqual("Amos.1.1", "parsing: 'AMOS 1:1'")
+		expect(p.parse("AM 1:1").osis()).toEqual("Amos.1.1", "parsing: 'AM 1:1'")
 		`
 		true
 describe "Localized book Obad (de)", ->
@@ -978,15 +1132,15 @@ describe "Localized book Obad (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Obad (de)", ->
 		`
-		expect(p.parse("Abdias 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("Obadja 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("Obad 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("Obd 1:1").osis()).toEqual("Obad.1.1")
+		expect(p.parse("Abdias 1:1").osis()).toEqual("Obad.1.1", "parsing: 'Abdias 1:1'")
+		expect(p.parse("Obadja 1:1").osis()).toEqual("Obad.1.1", "parsing: 'Obadja 1:1'")
+		expect(p.parse("Obad 1:1").osis()).toEqual("Obad.1.1", "parsing: 'Obad 1:1'")
+		expect(p.parse("Obd 1:1").osis()).toEqual("Obad.1.1", "parsing: 'Obd 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ABDIAS 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("OBADJA 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("OBAD 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("OBD 1:1").osis()).toEqual("Obad.1.1")
+		expect(p.parse("ABDIAS 1:1").osis()).toEqual("Obad.1.1", "parsing: 'ABDIAS 1:1'")
+		expect(p.parse("OBADJA 1:1").osis()).toEqual("Obad.1.1", "parsing: 'OBADJA 1:1'")
+		expect(p.parse("OBAD 1:1").osis()).toEqual("Obad.1.1", "parsing: 'OBAD 1:1'")
+		expect(p.parse("OBD 1:1").osis()).toEqual("Obad.1.1", "parsing: 'OBD 1:1'")
 		`
 		true
 describe "Localized book Jonah (de)", ->
@@ -997,13 +1151,13 @@ describe "Localized book Jonah (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Jonah (de)", ->
 		`
-		expect(p.parse("Jonah 1:1").osis()).toEqual("Jonah.1.1")
-		expect(p.parse("Jonas 1:1").osis()).toEqual("Jonah.1.1")
-		expect(p.parse("Jona 1:1").osis()).toEqual("Jonah.1.1")
+		expect(p.parse("Jonah 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'Jonah 1:1'")
+		expect(p.parse("Jonas 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'Jonas 1:1'")
+		expect(p.parse("Jona 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'Jona 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JONAH 1:1").osis()).toEqual("Jonah.1.1")
-		expect(p.parse("JONAS 1:1").osis()).toEqual("Jonah.1.1")
-		expect(p.parse("JONA 1:1").osis()).toEqual("Jonah.1.1")
+		expect(p.parse("JONAH 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'JONAH 1:1'")
+		expect(p.parse("JONAS 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'JONAS 1:1'")
+		expect(p.parse("JONA 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'JONA 1:1'")
 		`
 		true
 describe "Localized book Mic (de)", ->
@@ -1014,17 +1168,21 @@ describe "Localized book Mic (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Mic (de)", ->
 		`
-		expect(p.parse("Michaas 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("Michäas 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("Micha 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("Mic 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("Mi 1:1").osis()).toEqual("Mic.1.1")
+		expect(p.parse("Michaeas 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Michaeas 1:1'")
+		expect(p.parse("Michaas 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Michaas 1:1'")
+		expect(p.parse("Michäas 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Michäas 1:1'")
+		expect(p.parse("Micha 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Micha 1:1'")
+		expect(p.parse("Mich 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Mich 1:1'")
+		expect(p.parse("Mic 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Mic 1:1'")
+		expect(p.parse("Mi 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Mi 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("MICHAAS 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("MICHÄAS 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("MICHA 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("MIC 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("MI 1:1").osis()).toEqual("Mic.1.1")
+		expect(p.parse("MICHAEAS 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICHAEAS 1:1'")
+		expect(p.parse("MICHAAS 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICHAAS 1:1'")
+		expect(p.parse("MICHÄAS 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICHÄAS 1:1'")
+		expect(p.parse("MICHA 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICHA 1:1'")
+		expect(p.parse("MICH 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICH 1:1'")
+		expect(p.parse("MIC 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MIC 1:1'")
+		expect(p.parse("MI 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MI 1:1'")
 		`
 		true
 describe "Localized book Nah (de)", ->
@@ -1035,11 +1193,11 @@ describe "Localized book Nah (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Nah (de)", ->
 		`
-		expect(p.parse("Nahum 1:1").osis()).toEqual("Nah.1.1")
-		expect(p.parse("Nah 1:1").osis()).toEqual("Nah.1.1")
+		expect(p.parse("Nahum 1:1").osis()).toEqual("Nah.1.1", "parsing: 'Nahum 1:1'")
+		expect(p.parse("Nah 1:1").osis()).toEqual("Nah.1.1", "parsing: 'Nah 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("NAHUM 1:1").osis()).toEqual("Nah.1.1")
-		expect(p.parse("NAH 1:1").osis()).toEqual("Nah.1.1")
+		expect(p.parse("NAHUM 1:1").osis()).toEqual("Nah.1.1", "parsing: 'NAHUM 1:1'")
+		expect(p.parse("NAH 1:1").osis()).toEqual("Nah.1.1", "parsing: 'NAH 1:1'")
 		`
 		true
 describe "Localized book Hab (de)", ->
@@ -1050,11 +1208,11 @@ describe "Localized book Hab (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Hab (de)", ->
 		`
-		expect(p.parse("Habakuk 1:1").osis()).toEqual("Hab.1.1")
-		expect(p.parse("Hab 1:1").osis()).toEqual("Hab.1.1")
+		expect(p.parse("Habakuk 1:1").osis()).toEqual("Hab.1.1", "parsing: 'Habakuk 1:1'")
+		expect(p.parse("Hab 1:1").osis()).toEqual("Hab.1.1", "parsing: 'Hab 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HABAKUK 1:1").osis()).toEqual("Hab.1.1")
-		expect(p.parse("HAB 1:1").osis()).toEqual("Hab.1.1")
+		expect(p.parse("HABAKUK 1:1").osis()).toEqual("Hab.1.1", "parsing: 'HABAKUK 1:1'")
+		expect(p.parse("HAB 1:1").osis()).toEqual("Hab.1.1", "parsing: 'HAB 1:1'")
 		`
 		true
 describe "Localized book Zeph (de)", ->
@@ -1065,19 +1223,15 @@ describe "Localized book Zeph (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Zeph (de)", ->
 		`
-		expect(p.parse("Sophonias 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Zephanja 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Zefanja 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Soph 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Zeph 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Zef 1:1").osis()).toEqual("Zeph.1.1")
+		expect(p.parse("Zephanja 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'Zephanja 1:1'")
+		expect(p.parse("Zefanja 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'Zefanja 1:1'")
+		expect(p.parse("Zeph 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'Zeph 1:1'")
+		expect(p.parse("Zef 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'Zef 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("SOPHONIAS 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("ZEPHANJA 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("ZEFANJA 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("SOPH 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("ZEPH 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("ZEF 1:1").osis()).toEqual("Zeph.1.1")
+		expect(p.parse("ZEPHANJA 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'ZEPHANJA 1:1'")
+		expect(p.parse("ZEFANJA 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'ZEFANJA 1:1'")
+		expect(p.parse("ZEPH 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'ZEPH 1:1'")
+		expect(p.parse("ZEF 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'ZEF 1:1'")
 		`
 		true
 describe "Localized book Hag (de)", ->
@@ -1088,19 +1242,13 @@ describe "Localized book Hag (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Hag (de)", ->
 		`
-		expect(p.parse("Aggaus 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Aggäus 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Haggai 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Agg 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Hag 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Ag 1:1").osis()).toEqual("Hag.1.1")
+		expect(p.parse("Haggai 1:1").osis()).toEqual("Hag.1.1", "parsing: 'Haggai 1:1'")
+		expect(p.parse("Hagg 1:1").osis()).toEqual("Hag.1.1", "parsing: 'Hagg 1:1'")
+		expect(p.parse("Hag 1:1").osis()).toEqual("Hag.1.1", "parsing: 'Hag 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("AGGAUS 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("AGGÄUS 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("HAGGAI 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("AGG 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("HAG 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("AG 1:1").osis()).toEqual("Hag.1.1")
+		expect(p.parse("HAGGAI 1:1").osis()).toEqual("Hag.1.1", "parsing: 'HAGGAI 1:1'")
+		expect(p.parse("HAGG 1:1").osis()).toEqual("Hag.1.1", "parsing: 'HAGG 1:1'")
+		expect(p.parse("HAG 1:1").osis()).toEqual("Hag.1.1", "parsing: 'HAG 1:1'")
 		`
 		true
 describe "Localized book Zech (de)", ->
@@ -1111,15 +1259,15 @@ describe "Localized book Zech (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Zech (de)", ->
 		`
-		expect(p.parse("Zacharias 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("Sacharja 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("Sach 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("Zech 1:1").osis()).toEqual("Zech.1.1")
+		expect(p.parse("Zacharias 1:1").osis()).toEqual("Zech.1.1", "parsing: 'Zacharias 1:1'")
+		expect(p.parse("Sacharja 1:1").osis()).toEqual("Zech.1.1", "parsing: 'Sacharja 1:1'")
+		expect(p.parse("Sach 1:1").osis()).toEqual("Zech.1.1", "parsing: 'Sach 1:1'")
+		expect(p.parse("Zech 1:1").osis()).toEqual("Zech.1.1", "parsing: 'Zech 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZACHARIAS 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("SACHARJA 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("SACH 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("ZECH 1:1").osis()).toEqual("Zech.1.1")
+		expect(p.parse("ZACHARIAS 1:1").osis()).toEqual("Zech.1.1", "parsing: 'ZACHARIAS 1:1'")
+		expect(p.parse("SACHARJA 1:1").osis()).toEqual("Zech.1.1", "parsing: 'SACHARJA 1:1'")
+		expect(p.parse("SACH 1:1").osis()).toEqual("Zech.1.1", "parsing: 'SACH 1:1'")
+		expect(p.parse("ZECH 1:1").osis()).toEqual("Zech.1.1", "parsing: 'ZECH 1:1'")
 		`
 		true
 describe "Localized book Mal (de)", ->
@@ -1130,13 +1278,13 @@ describe "Localized book Mal (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Mal (de)", ->
 		`
-		expect(p.parse("Malachias 1:1").osis()).toEqual("Mal.1.1")
-		expect(p.parse("Maleachi 1:1").osis()).toEqual("Mal.1.1")
-		expect(p.parse("Mal 1:1").osis()).toEqual("Mal.1.1")
+		expect(p.parse("Malachias 1:1").osis()).toEqual("Mal.1.1", "parsing: 'Malachias 1:1'")
+		expect(p.parse("Maleachi 1:1").osis()).toEqual("Mal.1.1", "parsing: 'Maleachi 1:1'")
+		expect(p.parse("Mal 1:1").osis()).toEqual("Mal.1.1", "parsing: 'Mal 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("MALACHIAS 1:1").osis()).toEqual("Mal.1.1")
-		expect(p.parse("MALEACHI 1:1").osis()).toEqual("Mal.1.1")
-		expect(p.parse("MAL 1:1").osis()).toEqual("Mal.1.1")
+		expect(p.parse("MALACHIAS 1:1").osis()).toEqual("Mal.1.1", "parsing: 'MALACHIAS 1:1'")
+		expect(p.parse("MALEACHI 1:1").osis()).toEqual("Mal.1.1", "parsing: 'MALEACHI 1:1'")
+		expect(p.parse("MAL 1:1").osis()).toEqual("Mal.1.1", "parsing: 'MAL 1:1'")
 		`
 		true
 describe "Localized book Matt (de)", ->
@@ -1147,27 +1295,35 @@ describe "Localized book Matt (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Matt (de)", ->
 		`
-		expect(p.parse("Das Evangelium nach Matthaus 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Das Evangelium nach Matthäus 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Evangelium nach Matthaus 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Evangelium nach Matthäus 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Matthausevangelium 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Matthäusevangelium 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Matthaus 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Matthäus 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Matt 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Mt 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("Das Evangelium nach Matthaeus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Das Evangelium nach Matthaeus 1:1'")
+		expect(p.parse("Das Evangelium nach Matthaus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Das Evangelium nach Matthaus 1:1'")
+		expect(p.parse("Das Evangelium nach Matthäus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Das Evangelium nach Matthäus 1:1'")
+		expect(p.parse(" Evangelium nach Matthaeus 1:1").osis()).toEqual("Matt.1.1", "parsing: ' Evangelium nach Matthaeus 1:1'")
+		expect(p.parse(" Evangelium nach Matthaus 1:1").osis()).toEqual("Matt.1.1", "parsing: ' Evangelium nach Matthaus 1:1'")
+		expect(p.parse(" Evangelium nach Matthäus 1:1").osis()).toEqual("Matt.1.1", "parsing: ' Evangelium nach Matthäus 1:1'")
+		expect(p.parse("Matthaeusevangelium 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthaeusevangelium 1:1'")
+		expect(p.parse("Matthausevangelium 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthausevangelium 1:1'")
+		expect(p.parse("Matthäusevangelium 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthäusevangelium 1:1'")
+		expect(p.parse("Matthaeus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthaeus 1:1'")
+		expect(p.parse("Matthaus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthaus 1:1'")
+		expect(p.parse("Matthäus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthäus 1:1'")
+		expect(p.parse("Matt 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matt 1:1'")
+		expect(p.parse("Mt 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Mt 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DAS EVANGELIUM NACH MATTHAUS 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("DAS EVANGELIUM NACH MATTHÄUS 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("EVANGELIUM NACH MATTHAUS 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("EVANGELIUM NACH MATTHÄUS 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("MATTHAUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("MATTHÄUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("MATTHAUS 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("MATTHÄUS 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("MATT 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("MT 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("DAS EVANGELIUM NACH MATTHAEUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'DAS EVANGELIUM NACH MATTHAEUS 1:1'")
+		expect(p.parse("DAS EVANGELIUM NACH MATTHAUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'DAS EVANGELIUM NACH MATTHAUS 1:1'")
+		expect(p.parse("DAS EVANGELIUM NACH MATTHÄUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'DAS EVANGELIUM NACH MATTHÄUS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH MATTHAEUS 1:1").osis()).toEqual("Matt.1.1", "parsing: ' EVANGELIUM NACH MATTHAEUS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH MATTHAUS 1:1").osis()).toEqual("Matt.1.1", "parsing: ' EVANGELIUM NACH MATTHAUS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH MATTHÄUS 1:1").osis()).toEqual("Matt.1.1", "parsing: ' EVANGELIUM NACH MATTHÄUS 1:1'")
+		expect(p.parse("MATTHAEUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHAEUSEVANGELIUM 1:1'")
+		expect(p.parse("MATTHAUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHAUSEVANGELIUM 1:1'")
+		expect(p.parse("MATTHÄUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHÄUSEVANGELIUM 1:1'")
+		expect(p.parse("MATTHAEUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHAEUS 1:1'")
+		expect(p.parse("MATTHAUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHAUS 1:1'")
+		expect(p.parse("MATTHÄUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHÄUS 1:1'")
+		expect(p.parse("MATT 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATT 1:1'")
+		expect(p.parse("MT 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MT 1:1'")
 		`
 		true
 describe "Localized book Mark (de)", ->
@@ -1178,19 +1334,19 @@ describe "Localized book Mark (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Mark (de)", ->
 		`
-		expect(p.parse("Das Evangelium nach Markus 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("Evangelium nach Markus 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("Markusevangelium 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("Markus 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("Mark 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("Mk 1:1").osis()).toEqual("Mark.1.1")
+		expect(p.parse("Das Evangelium nach Markus 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Das Evangelium nach Markus 1:1'")
+		expect(p.parse(" Evangelium nach Markus 1:1").osis()).toEqual("Mark.1.1", "parsing: ' Evangelium nach Markus 1:1'")
+		expect(p.parse("Markusevangelium 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Markusevangelium 1:1'")
+		expect(p.parse("Markus 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Markus 1:1'")
+		expect(p.parse("Mark 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Mark 1:1'")
+		expect(p.parse("Mk 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Mk 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DAS EVANGELIUM NACH MARKUS 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("EVANGELIUM NACH MARKUS 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("MARKUSEVANGELIUM 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("MARKUS 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("MARK 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("MK 1:1").osis()).toEqual("Mark.1.1")
+		expect(p.parse("DAS EVANGELIUM NACH MARKUS 1:1").osis()).toEqual("Mark.1.1", "parsing: 'DAS EVANGELIUM NACH MARKUS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH MARKUS 1:1").osis()).toEqual("Mark.1.1", "parsing: ' EVANGELIUM NACH MARKUS 1:1'")
+		expect(p.parse("MARKUSEVANGELIUM 1:1").osis()).toEqual("Mark.1.1", "parsing: 'MARKUSEVANGELIUM 1:1'")
+		expect(p.parse("MARKUS 1:1").osis()).toEqual("Mark.1.1", "parsing: 'MARKUS 1:1'")
+		expect(p.parse("MARK 1:1").osis()).toEqual("Mark.1.1", "parsing: 'MARK 1:1'")
+		expect(p.parse("MK 1:1").osis()).toEqual("Mark.1.1", "parsing: 'MK 1:1'")
 		`
 		true
 describe "Localized book Luke (de)", ->
@@ -1201,19 +1357,21 @@ describe "Localized book Luke (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Luke (de)", ->
 		`
-		expect(p.parse("Das Evangelium nach Lukas 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("Evangelium nach Lukas 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("Lukasevangelium 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("Lukas 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("Luke 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("Lk 1:1").osis()).toEqual("Luke.1.1")
+		expect(p.parse("Das Evangelium nach Lukas 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Das Evangelium nach Lukas 1:1'")
+		expect(p.parse(" Evangelium nach Lukas 1:1").osis()).toEqual("Luke.1.1", "parsing: ' Evangelium nach Lukas 1:1'")
+		expect(p.parse("Lukasevangelium 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Lukasevangelium 1:1'")
+		expect(p.parse("Lukas 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Lukas 1:1'")
+		expect(p.parse("Luke 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Luke 1:1'")
+		expect(p.parse("Luk 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Luk 1:1'")
+		expect(p.parse("Lk 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Lk 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DAS EVANGELIUM NACH LUKAS 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("EVANGELIUM NACH LUKAS 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("LUKASEVANGELIUM 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("LUKAS 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("LUKE 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("LK 1:1").osis()).toEqual("Luke.1.1")
+		expect(p.parse("DAS EVANGELIUM NACH LUKAS 1:1").osis()).toEqual("Luke.1.1", "parsing: 'DAS EVANGELIUM NACH LUKAS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH LUKAS 1:1").osis()).toEqual("Luke.1.1", "parsing: ' EVANGELIUM NACH LUKAS 1:1'")
+		expect(p.parse("LUKASEVANGELIUM 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LUKASEVANGELIUM 1:1'")
+		expect(p.parse("LUKAS 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LUKAS 1:1'")
+		expect(p.parse("LUKE 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LUKE 1:1'")
+		expect(p.parse("LUK 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LUK 1:1'")
+		expect(p.parse("LK 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LK 1:1'")
 		`
 		true
 describe "Localized book 1John (de)", ->
@@ -1224,23 +1382,29 @@ describe "Localized book 1John (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1John (de)", ->
 		`
-		expect(p.parse("Ersten Johannes 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("Erstes Johannes 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("Erste Johannes 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1. Johannes 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1 Johannes 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1. Joh 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1 Joh 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1John 1:1").osis()).toEqual("1John.1.1")
+		expect(p.parse("Ersten Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: 'Ersten Johannes 1:1'")
+		expect(p.parse("Erster Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: 'Erster Johannes 1:1'")
+		expect(p.parse("Erstes Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: 'Erstes Johannes 1:1'")
+		expect(p.parse("Erste Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: 'Erste Johannes 1:1'")
+		expect(p.parse("1. Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: '1. Johannes 1:1'")
+		expect(p.parse("1 Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: '1 Johannes 1:1'")
+		expect(p.parse("1. Joh 1:1").osis()).toEqual("1John.1.1", "parsing: '1. Joh 1:1'")
+		expect(p.parse("1 Joh 1:1").osis()).toEqual("1John.1.1", "parsing: '1 Joh 1:1'")
+		expect(p.parse("1. Jo 1:1").osis()).toEqual("1John.1.1", "parsing: '1. Jo 1:1'")
+		expect(p.parse("1John 1:1").osis()).toEqual("1John.1.1", "parsing: '1John 1:1'")
+		expect(p.parse("1 Jo 1:1").osis()).toEqual("1John.1.1", "parsing: '1 Jo 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTEN JOHANNES 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("ERSTES JOHANNES 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("ERSTE JOHANNES 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1. JOHANNES 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1 JOHANNES 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1. JOH 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1 JOH 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1JOHN 1:1").osis()).toEqual("1John.1.1")
+		expect(p.parse("ERSTEN JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: 'ERSTEN JOHANNES 1:1'")
+		expect(p.parse("ERSTER JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: 'ERSTER JOHANNES 1:1'")
+		expect(p.parse("ERSTES JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: 'ERSTES JOHANNES 1:1'")
+		expect(p.parse("ERSTE JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: 'ERSTE JOHANNES 1:1'")
+		expect(p.parse("1. JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: '1. JOHANNES 1:1'")
+		expect(p.parse("1 JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: '1 JOHANNES 1:1'")
+		expect(p.parse("1. JOH 1:1").osis()).toEqual("1John.1.1", "parsing: '1. JOH 1:1'")
+		expect(p.parse("1 JOH 1:1").osis()).toEqual("1John.1.1", "parsing: '1 JOH 1:1'")
+		expect(p.parse("1. JO 1:1").osis()).toEqual("1John.1.1", "parsing: '1. JO 1:1'")
+		expect(p.parse("1JOHN 1:1").osis()).toEqual("1John.1.1", "parsing: '1JOHN 1:1'")
+		expect(p.parse("1 JO 1:1").osis()).toEqual("1John.1.1", "parsing: '1 JO 1:1'")
 		`
 		true
 describe "Localized book 2John (de)", ->
@@ -1251,23 +1415,29 @@ describe "Localized book 2John (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2John (de)", ->
 		`
-		expect(p.parse("Zweiten Johannes 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("Zweites Johannes 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("Zweite Johannes 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2. Johannes 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2 Johannes 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2. Joh 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2 Joh 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2John 1:1").osis()).toEqual("2John.1.1")
+		expect(p.parse("Zweiten Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: 'Zweiten Johannes 1:1'")
+		expect(p.parse("Zweiter Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: 'Zweiter Johannes 1:1'")
+		expect(p.parse("Zweites Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: 'Zweites Johannes 1:1'")
+		expect(p.parse("Zweite Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: 'Zweite Johannes 1:1'")
+		expect(p.parse("2. Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: '2. Johannes 1:1'")
+		expect(p.parse("2 Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: '2 Johannes 1:1'")
+		expect(p.parse("2. Joh 1:1").osis()).toEqual("2John.1.1", "parsing: '2. Joh 1:1'")
+		expect(p.parse("2 Joh 1:1").osis()).toEqual("2John.1.1", "parsing: '2 Joh 1:1'")
+		expect(p.parse("2. Jo 1:1").osis()).toEqual("2John.1.1", "parsing: '2. Jo 1:1'")
+		expect(p.parse("2John 1:1").osis()).toEqual("2John.1.1", "parsing: '2John 1:1'")
+		expect(p.parse("2 Jo 1:1").osis()).toEqual("2John.1.1", "parsing: '2 Jo 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITEN JOHANNES 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("ZWEITES JOHANNES 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("ZWEITE JOHANNES 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2. JOHANNES 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2 JOHANNES 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2. JOH 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2 JOH 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2JOHN 1:1").osis()).toEqual("2John.1.1")
+		expect(p.parse("ZWEITEN JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: 'ZWEITEN JOHANNES 1:1'")
+		expect(p.parse("ZWEITER JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: 'ZWEITER JOHANNES 1:1'")
+		expect(p.parse("ZWEITES JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: 'ZWEITES JOHANNES 1:1'")
+		expect(p.parse("ZWEITE JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: 'ZWEITE JOHANNES 1:1'")
+		expect(p.parse("2. JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: '2. JOHANNES 1:1'")
+		expect(p.parse("2 JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: '2 JOHANNES 1:1'")
+		expect(p.parse("2. JOH 1:1").osis()).toEqual("2John.1.1", "parsing: '2. JOH 1:1'")
+		expect(p.parse("2 JOH 1:1").osis()).toEqual("2John.1.1", "parsing: '2 JOH 1:1'")
+		expect(p.parse("2. JO 1:1").osis()).toEqual("2John.1.1", "parsing: '2. JO 1:1'")
+		expect(p.parse("2JOHN 1:1").osis()).toEqual("2John.1.1", "parsing: '2JOHN 1:1'")
+		expect(p.parse("2 JO 1:1").osis()).toEqual("2John.1.1", "parsing: '2 JO 1:1'")
 		`
 		true
 describe "Localized book 3John (de)", ->
@@ -1278,23 +1448,29 @@ describe "Localized book 3John (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 3John (de)", ->
 		`
-		expect(p.parse("Dritten Johannes 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("Drittes Johannes 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("Dritte Johannes 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3. Johannes 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3 Johannes 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3. Joh 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3 Joh 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3John 1:1").osis()).toEqual("3John.1.1")
+		expect(p.parse("Dritten Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: 'Dritten Johannes 1:1'")
+		expect(p.parse("Dritter Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: 'Dritter Johannes 1:1'")
+		expect(p.parse("Drittes Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: 'Drittes Johannes 1:1'")
+		expect(p.parse("Dritte Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: 'Dritte Johannes 1:1'")
+		expect(p.parse("3. Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: '3. Johannes 1:1'")
+		expect(p.parse("3 Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: '3 Johannes 1:1'")
+		expect(p.parse("3. Joh 1:1").osis()).toEqual("3John.1.1", "parsing: '3. Joh 1:1'")
+		expect(p.parse("3 Joh 1:1").osis()).toEqual("3John.1.1", "parsing: '3 Joh 1:1'")
+		expect(p.parse("3. Jo 1:1").osis()).toEqual("3John.1.1", "parsing: '3. Jo 1:1'")
+		expect(p.parse("3John 1:1").osis()).toEqual("3John.1.1", "parsing: '3John 1:1'")
+		expect(p.parse("3 Jo 1:1").osis()).toEqual("3John.1.1", "parsing: '3 Jo 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DRITTEN JOHANNES 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("DRITTES JOHANNES 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("DRITTE JOHANNES 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3. JOHANNES 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3 JOHANNES 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3. JOH 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3 JOH 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3JOHN 1:1").osis()).toEqual("3John.1.1")
+		expect(p.parse("DRITTEN JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: 'DRITTEN JOHANNES 1:1'")
+		expect(p.parse("DRITTER JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: 'DRITTER JOHANNES 1:1'")
+		expect(p.parse("DRITTES JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: 'DRITTES JOHANNES 1:1'")
+		expect(p.parse("DRITTE JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: 'DRITTE JOHANNES 1:1'")
+		expect(p.parse("3. JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: '3. JOHANNES 1:1'")
+		expect(p.parse("3 JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: '3 JOHANNES 1:1'")
+		expect(p.parse("3. JOH 1:1").osis()).toEqual("3John.1.1", "parsing: '3. JOH 1:1'")
+		expect(p.parse("3 JOH 1:1").osis()).toEqual("3John.1.1", "parsing: '3 JOH 1:1'")
+		expect(p.parse("3. JO 1:1").osis()).toEqual("3John.1.1", "parsing: '3. JO 1:1'")
+		expect(p.parse("3JOHN 1:1").osis()).toEqual("3John.1.1", "parsing: '3JOHN 1:1'")
+		expect(p.parse("3 JO 1:1").osis()).toEqual("3John.1.1", "parsing: '3 JO 1:1'")
 		`
 		true
 describe "Localized book John (de)", ->
@@ -1305,19 +1481,19 @@ describe "Localized book John (de)", ->
 		p.include_apocrypha true
 	it "should handle book: John (de)", ->
 		`
-		expect(p.parse("Das Evangelium nach Johannes 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("Evangelium nach Johannes 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("Johannesevangelium 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("Johannes 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("John 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("Joh 1:1").osis()).toEqual("John.1.1")
+		expect(p.parse("Das Evangelium nach Johannes 1:1").osis()).toEqual("John.1.1", "parsing: 'Das Evangelium nach Johannes 1:1'")
+		expect(p.parse(" Evangelium nach Johannes 1:1").osis()).toEqual("John.1.1", "parsing: ' Evangelium nach Johannes 1:1'")
+		expect(p.parse("Johannesevangelium 1:1").osis()).toEqual("John.1.1", "parsing: 'Johannesevangelium 1:1'")
+		expect(p.parse("Johannes 1:1").osis()).toEqual("John.1.1", "parsing: 'Johannes 1:1'")
+		expect(p.parse("John 1:1").osis()).toEqual("John.1.1", "parsing: 'John 1:1'")
+		expect(p.parse("Joh 1:1").osis()).toEqual("John.1.1", "parsing: 'Joh 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DAS EVANGELIUM NACH JOHANNES 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("EVANGELIUM NACH JOHANNES 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("JOHANNESEVANGELIUM 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("JOHANNES 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("JOHN 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("JOH 1:1").osis()).toEqual("John.1.1")
+		expect(p.parse("DAS EVANGELIUM NACH JOHANNES 1:1").osis()).toEqual("John.1.1", "parsing: 'DAS EVANGELIUM NACH JOHANNES 1:1'")
+		expect(p.parse(" EVANGELIUM NACH JOHANNES 1:1").osis()).toEqual("John.1.1", "parsing: ' EVANGELIUM NACH JOHANNES 1:1'")
+		expect(p.parse("JOHANNESEVANGELIUM 1:1").osis()).toEqual("John.1.1", "parsing: 'JOHANNESEVANGELIUM 1:1'")
+		expect(p.parse("JOHANNES 1:1").osis()).toEqual("John.1.1", "parsing: 'JOHANNES 1:1'")
+		expect(p.parse("JOHN 1:1").osis()).toEqual("John.1.1", "parsing: 'JOHN 1:1'")
+		expect(p.parse("JOH 1:1").osis()).toEqual("John.1.1", "parsing: 'JOH 1:1'")
 		`
 		true
 describe "Localized book Acts (de)", ->
@@ -1328,13 +1504,13 @@ describe "Localized book Acts (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Acts (de)", ->
 		`
-		expect(p.parse("Apostelgeschichte 1:1").osis()).toEqual("Acts.1.1")
-		expect(p.parse("Acts 1:1").osis()).toEqual("Acts.1.1")
-		expect(p.parse("Apg 1:1").osis()).toEqual("Acts.1.1")
+		expect(p.parse("Apostelgeschichte 1:1").osis()).toEqual("Acts.1.1", "parsing: 'Apostelgeschichte 1:1'")
+		expect(p.parse("Acts 1:1").osis()).toEqual("Acts.1.1", "parsing: 'Acts 1:1'")
+		expect(p.parse("Apg 1:1").osis()).toEqual("Acts.1.1", "parsing: 'Apg 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("APOSTELGESCHICHTE 1:1").osis()).toEqual("Acts.1.1")
-		expect(p.parse("ACTS 1:1").osis()).toEqual("Acts.1.1")
-		expect(p.parse("APG 1:1").osis()).toEqual("Acts.1.1")
+		expect(p.parse("APOSTELGESCHICHTE 1:1").osis()).toEqual("Acts.1.1", "parsing: 'APOSTELGESCHICHTE 1:1'")
+		expect(p.parse("ACTS 1:1").osis()).toEqual("Acts.1.1", "parsing: 'ACTS 1:1'")
+		expect(p.parse("APG 1:1").osis()).toEqual("Acts.1.1", "parsing: 'APG 1:1'")
 		`
 		true
 describe "Localized book Rom (de)", ->
@@ -1345,15 +1521,21 @@ describe "Localized book Rom (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Rom (de)", ->
 		`
-		expect(p.parse("Roemer 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("Römer 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("Rom 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("Röm 1:1").osis()).toEqual("Rom.1.1")
+		expect(p.parse("Roemer 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Roemer 1:1'")
+		expect(p.parse("Romer 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Romer 1:1'")
+		expect(p.parse("Römer 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Römer 1:1'")
+		expect(p.parse("Roem 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Roem 1:1'")
+		expect(p.parse("Rom 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Rom 1:1'")
+		expect(p.parse("Röm 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Röm 1:1'")
+		expect(p.parse("Rm 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Rm 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ROEMER 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("RÖMER 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("ROM 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("RÖM 1:1").osis()).toEqual("Rom.1.1")
+		expect(p.parse("ROEMER 1:1").osis()).toEqual("Rom.1.1", "parsing: 'ROEMER 1:1'")
+		expect(p.parse("ROMER 1:1").osis()).toEqual("Rom.1.1", "parsing: 'ROMER 1:1'")
+		expect(p.parse("RÖMER 1:1").osis()).toEqual("Rom.1.1", "parsing: 'RÖMER 1:1'")
+		expect(p.parse("ROEM 1:1").osis()).toEqual("Rom.1.1", "parsing: 'ROEM 1:1'")
+		expect(p.parse("ROM 1:1").osis()).toEqual("Rom.1.1", "parsing: 'ROM 1:1'")
+		expect(p.parse("RÖM 1:1").osis()).toEqual("Rom.1.1", "parsing: 'RÖM 1:1'")
+		expect(p.parse("RM 1:1").osis()).toEqual("Rom.1.1", "parsing: 'RM 1:1'")
 		`
 		true
 describe "Localized book 2Cor (de)", ->
@@ -1364,23 +1546,25 @@ describe "Localized book 2Cor (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Cor (de)", ->
 		`
-		expect(p.parse("Zweiten Korinther 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("Zweites Korinther 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("Zweite Korinther 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2. Korinther 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2 Korinther 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2. Kor 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2 Kor 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2Cor 1:1").osis()).toEqual("2Cor.1.1")
+		expect(p.parse("Zweiten Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'Zweiten Korinther 1:1'")
+		expect(p.parse("Zweiter Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'Zweiter Korinther 1:1'")
+		expect(p.parse("Zweites Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'Zweites Korinther 1:1'")
+		expect(p.parse("Zweite Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'Zweite Korinther 1:1'")
+		expect(p.parse("2. Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2. Korinther 1:1'")
+		expect(p.parse("2 Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2 Korinther 1:1'")
+		expect(p.parse("2. Kor 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2. Kor 1:1'")
+		expect(p.parse("2 Kor 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2 Kor 1:1'")
+		expect(p.parse("2Cor 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2Cor 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITEN KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("ZWEITES KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("ZWEITE KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2. KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2 KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2. KOR 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2 KOR 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2COR 1:1").osis()).toEqual("2Cor.1.1")
+		expect(p.parse("ZWEITEN KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'ZWEITEN KORINTHER 1:1'")
+		expect(p.parse("ZWEITER KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'ZWEITER KORINTHER 1:1'")
+		expect(p.parse("ZWEITES KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'ZWEITES KORINTHER 1:1'")
+		expect(p.parse("ZWEITE KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'ZWEITE KORINTHER 1:1'")
+		expect(p.parse("2. KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2. KORINTHER 1:1'")
+		expect(p.parse("2 KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2 KORINTHER 1:1'")
+		expect(p.parse("2. KOR 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2. KOR 1:1'")
+		expect(p.parse("2 KOR 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2 KOR 1:1'")
+		expect(p.parse("2COR 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2COR 1:1'")
 		`
 		true
 describe "Localized book 1Cor (de)", ->
@@ -1391,23 +1575,25 @@ describe "Localized book 1Cor (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Cor (de)", ->
 		`
-		expect(p.parse("Ersten Korinther 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("Erstes Korinther 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("Erste Korinther 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1. Korinther 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1 Korinther 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1. Kor 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1 Kor 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1Cor 1:1").osis()).toEqual("1Cor.1.1")
+		expect(p.parse("Ersten Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'Ersten Korinther 1:1'")
+		expect(p.parse("Erster Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'Erster Korinther 1:1'")
+		expect(p.parse("Erstes Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'Erstes Korinther 1:1'")
+		expect(p.parse("Erste Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'Erste Korinther 1:1'")
+		expect(p.parse("1. Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1. Korinther 1:1'")
+		expect(p.parse("1 Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1 Korinther 1:1'")
+		expect(p.parse("1. Kor 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1. Kor 1:1'")
+		expect(p.parse("1 Kor 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1 Kor 1:1'")
+		expect(p.parse("1Cor 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1Cor 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTEN KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("ERSTES KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("ERSTE KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1. KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1 KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1. KOR 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1 KOR 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1COR 1:1").osis()).toEqual("1Cor.1.1")
+		expect(p.parse("ERSTEN KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'ERSTEN KORINTHER 1:1'")
+		expect(p.parse("ERSTER KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'ERSTER KORINTHER 1:1'")
+		expect(p.parse("ERSTES KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'ERSTES KORINTHER 1:1'")
+		expect(p.parse("ERSTE KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'ERSTE KORINTHER 1:1'")
+		expect(p.parse("1. KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1. KORINTHER 1:1'")
+		expect(p.parse("1 KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1 KORINTHER 1:1'")
+		expect(p.parse("1. KOR 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1. KOR 1:1'")
+		expect(p.parse("1 KOR 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1 KOR 1:1'")
+		expect(p.parse("1COR 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1COR 1:1'")
 		`
 		true
 describe "Localized book Gal (de)", ->
@@ -1418,11 +1604,11 @@ describe "Localized book Gal (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Gal (de)", ->
 		`
-		expect(p.parse("Galater 1:1").osis()).toEqual("Gal.1.1")
-		expect(p.parse("Gal 1:1").osis()).toEqual("Gal.1.1")
+		expect(p.parse("Galater 1:1").osis()).toEqual("Gal.1.1", "parsing: 'Galater 1:1'")
+		expect(p.parse("Gal 1:1").osis()).toEqual("Gal.1.1", "parsing: 'Gal 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("GALATER 1:1").osis()).toEqual("Gal.1.1")
-		expect(p.parse("GAL 1:1").osis()).toEqual("Gal.1.1")
+		expect(p.parse("GALATER 1:1").osis()).toEqual("Gal.1.1", "parsing: 'GALATER 1:1'")
+		expect(p.parse("GAL 1:1").osis()).toEqual("Gal.1.1", "parsing: 'GAL 1:1'")
 		`
 		true
 describe "Localized book Eph (de)", ->
@@ -1433,11 +1619,11 @@ describe "Localized book Eph (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Eph (de)", ->
 		`
-		expect(p.parse("Epheser 1:1").osis()).toEqual("Eph.1.1")
-		expect(p.parse("Eph 1:1").osis()).toEqual("Eph.1.1")
+		expect(p.parse("Epheser 1:1").osis()).toEqual("Eph.1.1", "parsing: 'Epheser 1:1'")
+		expect(p.parse("Eph 1:1").osis()).toEqual("Eph.1.1", "parsing: 'Eph 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("EPHESER 1:1").osis()).toEqual("Eph.1.1")
-		expect(p.parse("EPH 1:1").osis()).toEqual("Eph.1.1")
+		expect(p.parse("EPHESER 1:1").osis()).toEqual("Eph.1.1", "parsing: 'EPHESER 1:1'")
+		expect(p.parse("EPH 1:1").osis()).toEqual("Eph.1.1", "parsing: 'EPH 1:1'")
 		`
 		true
 describe "Localized book Phil (de)", ->
@@ -1448,11 +1634,11 @@ describe "Localized book Phil (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Phil (de)", ->
 		`
-		expect(p.parse("Philipper 1:1").osis()).toEqual("Phil.1.1")
-		expect(p.parse("Phil 1:1").osis()).toEqual("Phil.1.1")
+		expect(p.parse("Philipper 1:1").osis()).toEqual("Phil.1.1", "parsing: 'Philipper 1:1'")
+		expect(p.parse("Phil 1:1").osis()).toEqual("Phil.1.1", "parsing: 'Phil 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("PHILIPPER 1:1").osis()).toEqual("Phil.1.1")
-		expect(p.parse("PHIL 1:1").osis()).toEqual("Phil.1.1")
+		expect(p.parse("PHILIPPER 1:1").osis()).toEqual("Phil.1.1", "parsing: 'PHILIPPER 1:1'")
+		expect(p.parse("PHIL 1:1").osis()).toEqual("Phil.1.1", "parsing: 'PHIL 1:1'")
 		`
 		true
 describe "Localized book Col (de)", ->
@@ -1463,13 +1649,13 @@ describe "Localized book Col (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Col (de)", ->
 		`
-		expect(p.parse("Kolosser 1:1").osis()).toEqual("Col.1.1")
-		expect(p.parse("Col 1:1").osis()).toEqual("Col.1.1")
-		expect(p.parse("Kol 1:1").osis()).toEqual("Col.1.1")
+		expect(p.parse("Kolosser 1:1").osis()).toEqual("Col.1.1", "parsing: 'Kolosser 1:1'")
+		expect(p.parse("Col 1:1").osis()).toEqual("Col.1.1", "parsing: 'Col 1:1'")
+		expect(p.parse("Kol 1:1").osis()).toEqual("Col.1.1", "parsing: 'Kol 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("KOLOSSER 1:1").osis()).toEqual("Col.1.1")
-		expect(p.parse("COL 1:1").osis()).toEqual("Col.1.1")
-		expect(p.parse("KOL 1:1").osis()).toEqual("Col.1.1")
+		expect(p.parse("KOLOSSER 1:1").osis()).toEqual("Col.1.1", "parsing: 'KOLOSSER 1:1'")
+		expect(p.parse("COL 1:1").osis()).toEqual("Col.1.1", "parsing: 'COL 1:1'")
+		expect(p.parse("KOL 1:1").osis()).toEqual("Col.1.1", "parsing: 'KOL 1:1'")
 		`
 		true
 describe "Localized book 2Thess (de)", ->
@@ -1480,23 +1666,29 @@ describe "Localized book 2Thess (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Thess (de)", ->
 		`
-		expect(p.parse("Zweiten Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("Zweites Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("Zweite Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2. Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2 Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2. Thess 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2 Thess 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2Thess 1:1").osis()).toEqual("2Thess.1.1")
+		expect(p.parse("Zweiten Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'Zweiten Thessalonicher 1:1'")
+		expect(p.parse("Zweiter Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'Zweiter Thessalonicher 1:1'")
+		expect(p.parse("Zweites Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'Zweites Thessalonicher 1:1'")
+		expect(p.parse("Zweite Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'Zweite Thessalonicher 1:1'")
+		expect(p.parse("2. Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. Thessalonicher 1:1'")
+		expect(p.parse("2 Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 Thessalonicher 1:1'")
+		expect(p.parse("2. Thess 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. Thess 1:1'")
+		expect(p.parse("2 Thess 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 Thess 1:1'")
+		expect(p.parse("2Thess 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2Thess 1:1'")
+		expect(p.parse("2. Th 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. Th 1:1'")
+		expect(p.parse("2 Th 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 Th 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITEN THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("ZWEITES THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("ZWEITE THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2. THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2 THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2. THESS 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2 THESS 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2THESS 1:1").osis()).toEqual("2Thess.1.1")
+		expect(p.parse("ZWEITEN THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'ZWEITEN THESSALONICHER 1:1'")
+		expect(p.parse("ZWEITER THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'ZWEITER THESSALONICHER 1:1'")
+		expect(p.parse("ZWEITES THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'ZWEITES THESSALONICHER 1:1'")
+		expect(p.parse("ZWEITE THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'ZWEITE THESSALONICHER 1:1'")
+		expect(p.parse("2. THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. THESSALONICHER 1:1'")
+		expect(p.parse("2 THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 THESSALONICHER 1:1'")
+		expect(p.parse("2. THESS 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. THESS 1:1'")
+		expect(p.parse("2 THESS 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 THESS 1:1'")
+		expect(p.parse("2THESS 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2THESS 1:1'")
+		expect(p.parse("2. TH 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. TH 1:1'")
+		expect(p.parse("2 TH 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 TH 1:1'")
 		`
 		true
 describe "Localized book 1Thess (de)", ->
@@ -1507,23 +1699,29 @@ describe "Localized book 1Thess (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Thess (de)", ->
 		`
-		expect(p.parse("Ersten Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("Erstes Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("Erste Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1. Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1 Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1. Thess 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1 Thess 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1Thess 1:1").osis()).toEqual("1Thess.1.1")
+		expect(p.parse("Ersten Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'Ersten Thessalonicher 1:1'")
+		expect(p.parse("Erster Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'Erster Thessalonicher 1:1'")
+		expect(p.parse("Erstes Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'Erstes Thessalonicher 1:1'")
+		expect(p.parse("Erste Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'Erste Thessalonicher 1:1'")
+		expect(p.parse("1. Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. Thessalonicher 1:1'")
+		expect(p.parse("1 Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 Thessalonicher 1:1'")
+		expect(p.parse("1. Thess 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. Thess 1:1'")
+		expect(p.parse("1 Thess 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 Thess 1:1'")
+		expect(p.parse("1Thess 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1Thess 1:1'")
+		expect(p.parse("1. Th 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. Th 1:1'")
+		expect(p.parse("1 Th 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 Th 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTEN THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("ERSTES THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("ERSTE THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1. THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1 THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1. THESS 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1 THESS 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1THESS 1:1").osis()).toEqual("1Thess.1.1")
+		expect(p.parse("ERSTEN THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'ERSTEN THESSALONICHER 1:1'")
+		expect(p.parse("ERSTER THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'ERSTER THESSALONICHER 1:1'")
+		expect(p.parse("ERSTES THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'ERSTES THESSALONICHER 1:1'")
+		expect(p.parse("ERSTE THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'ERSTE THESSALONICHER 1:1'")
+		expect(p.parse("1. THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. THESSALONICHER 1:1'")
+		expect(p.parse("1 THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 THESSALONICHER 1:1'")
+		expect(p.parse("1. THESS 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. THESS 1:1'")
+		expect(p.parse("1 THESS 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 THESS 1:1'")
+		expect(p.parse("1THESS 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1THESS 1:1'")
+		expect(p.parse("1. TH 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. TH 1:1'")
+		expect(p.parse("1 TH 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 TH 1:1'")
 		`
 		true
 describe "Localized book 2Tim (de)", ->
@@ -1534,23 +1732,25 @@ describe "Localized book 2Tim (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Tim (de)", ->
 		`
-		expect(p.parse("Zweiten Timotheus 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("Zweites Timotheus 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("Zweite Timotheus 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2. Timotheus 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2 Timotheus 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2. Tim 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2 Tim 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2Tim 1:1").osis()).toEqual("2Tim.1.1")
+		expect(p.parse("Zweiten Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'Zweiten Timotheus 1:1'")
+		expect(p.parse("Zweiter Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'Zweiter Timotheus 1:1'")
+		expect(p.parse("Zweites Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'Zweites Timotheus 1:1'")
+		expect(p.parse("Zweite Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'Zweite Timotheus 1:1'")
+		expect(p.parse("2. Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2. Timotheus 1:1'")
+		expect(p.parse("2 Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2 Timotheus 1:1'")
+		expect(p.parse("2. Tim 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2. Tim 1:1'")
+		expect(p.parse("2 Tim 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2 Tim 1:1'")
+		expect(p.parse("2Tim 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2Tim 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITEN TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("ZWEITES TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("ZWEITE TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2. TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2 TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2. TIM 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2 TIM 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2TIM 1:1").osis()).toEqual("2Tim.1.1")
+		expect(p.parse("ZWEITEN TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'ZWEITEN TIMOTHEUS 1:1'")
+		expect(p.parse("ZWEITER TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'ZWEITER TIMOTHEUS 1:1'")
+		expect(p.parse("ZWEITES TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'ZWEITES TIMOTHEUS 1:1'")
+		expect(p.parse("ZWEITE TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'ZWEITE TIMOTHEUS 1:1'")
+		expect(p.parse("2. TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2. TIMOTHEUS 1:1'")
+		expect(p.parse("2 TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2 TIMOTHEUS 1:1'")
+		expect(p.parse("2. TIM 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2. TIM 1:1'")
+		expect(p.parse("2 TIM 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2 TIM 1:1'")
+		expect(p.parse("2TIM 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2TIM 1:1'")
 		`
 		true
 describe "Localized book 1Tim (de)", ->
@@ -1561,23 +1761,25 @@ describe "Localized book 1Tim (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Tim (de)", ->
 		`
-		expect(p.parse("Ersten Timotheus 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("Erstes Timotheus 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("Erste Timotheus 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1. Timotheus 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1 Timotheus 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1. Tim 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1 Tim 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1Tim 1:1").osis()).toEqual("1Tim.1.1")
+		expect(p.parse("Ersten Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'Ersten Timotheus 1:1'")
+		expect(p.parse("Erster Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'Erster Timotheus 1:1'")
+		expect(p.parse("Erstes Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'Erstes Timotheus 1:1'")
+		expect(p.parse("Erste Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'Erste Timotheus 1:1'")
+		expect(p.parse("1. Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1. Timotheus 1:1'")
+		expect(p.parse("1 Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1 Timotheus 1:1'")
+		expect(p.parse("1. Tim 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1. Tim 1:1'")
+		expect(p.parse("1 Tim 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1 Tim 1:1'")
+		expect(p.parse("1Tim 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1Tim 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTEN TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("ERSTES TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("ERSTE TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1. TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1 TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1. TIM 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1 TIM 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1TIM 1:1").osis()).toEqual("1Tim.1.1")
+		expect(p.parse("ERSTEN TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'ERSTEN TIMOTHEUS 1:1'")
+		expect(p.parse("ERSTER TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'ERSTER TIMOTHEUS 1:1'")
+		expect(p.parse("ERSTES TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'ERSTES TIMOTHEUS 1:1'")
+		expect(p.parse("ERSTE TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'ERSTE TIMOTHEUS 1:1'")
+		expect(p.parse("1. TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1. TIMOTHEUS 1:1'")
+		expect(p.parse("1 TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1 TIMOTHEUS 1:1'")
+		expect(p.parse("1. TIM 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1. TIM 1:1'")
+		expect(p.parse("1 TIM 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1 TIM 1:1'")
+		expect(p.parse("1TIM 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1TIM 1:1'")
 		`
 		true
 describe "Localized book Titus (de)", ->
@@ -1588,11 +1790,11 @@ describe "Localized book Titus (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Titus (de)", ->
 		`
-		expect(p.parse("Titus 1:1").osis()).toEqual("Titus.1.1")
-		expect(p.parse("Tit 1:1").osis()).toEqual("Titus.1.1")
+		expect(p.parse("Titus 1:1").osis()).toEqual("Titus.1.1", "parsing: 'Titus 1:1'")
+		expect(p.parse("Tit 1:1").osis()).toEqual("Titus.1.1", "parsing: 'Tit 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("TITUS 1:1").osis()).toEqual("Titus.1.1")
-		expect(p.parse("TIT 1:1").osis()).toEqual("Titus.1.1")
+		expect(p.parse("TITUS 1:1").osis()).toEqual("Titus.1.1", "parsing: 'TITUS 1:1'")
+		expect(p.parse("TIT 1:1").osis()).toEqual("Titus.1.1", "parsing: 'TIT 1:1'")
 		`
 		true
 describe "Localized book Phlm (de)", ->
@@ -1603,13 +1805,13 @@ describe "Localized book Phlm (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Phlm (de)", ->
 		`
-		expect(p.parse("Philemon 1:1").osis()).toEqual("Phlm.1.1")
-		expect(p.parse("Phlm 1:1").osis()).toEqual("Phlm.1.1")
-		expect(p.parse("Phm 1:1").osis()).toEqual("Phlm.1.1")
+		expect(p.parse("Philemon 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'Philemon 1:1'")
+		expect(p.parse("Phlm 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'Phlm 1:1'")
+		expect(p.parse("Phm 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'Phm 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("PHILEMON 1:1").osis()).toEqual("Phlm.1.1")
-		expect(p.parse("PHLM 1:1").osis()).toEqual("Phlm.1.1")
-		expect(p.parse("PHM 1:1").osis()).toEqual("Phlm.1.1")
+		expect(p.parse("PHILEMON 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'PHILEMON 1:1'")
+		expect(p.parse("PHLM 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'PHLM 1:1'")
+		expect(p.parse("PHM 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'PHM 1:1'")
 		`
 		true
 describe "Localized book Heb (de)", ->
@@ -1620,17 +1822,19 @@ describe "Localized book Heb (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Heb (de)", ->
 		`
-		expect(p.parse("Hebraeer 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("Hebraer 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("Hebräer 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("Hebr 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("Heb 1:1").osis()).toEqual("Heb.1.1")
+		expect(p.parse("Hebraeer 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hebraeer 1:1'")
+		expect(p.parse("Hebraer 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hebraer 1:1'")
+		expect(p.parse("Hebräer 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hebräer 1:1'")
+		expect(p.parse("Hebr 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hebr 1:1'")
+		expect(p.parse("Heb 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Heb 1:1'")
+		expect(p.parse("Hb 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hb 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HEBRAEER 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("HEBRAER 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("HEBRÄER 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("HEBR 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("HEB 1:1").osis()).toEqual("Heb.1.1")
+		expect(p.parse("HEBRAEER 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEBRAEER 1:1'")
+		expect(p.parse("HEBRAER 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEBRAER 1:1'")
+		expect(p.parse("HEBRÄER 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEBRÄER 1:1'")
+		expect(p.parse("HEBR 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEBR 1:1'")
+		expect(p.parse("HEB 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEB 1:1'")
+		expect(p.parse("HB 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HB 1:1'")
 		`
 		true
 describe "Localized book Jas (de)", ->
@@ -1641,15 +1845,17 @@ describe "Localized book Jas (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Jas (de)", ->
 		`
-		expect(p.parse("Jakobusbrief 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("Jakobus 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("Jak 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("Jas 1:1").osis()).toEqual("Jas.1.1")
+		expect(p.parse("Jakobusbrief 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jakobusbrief 1:1'")
+		expect(p.parse("Jakobus 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jakobus 1:1'")
+		expect(p.parse("Jak 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jak 1:1'")
+		expect(p.parse("Jas 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jas 1:1'")
+		expect(p.parse("Jk 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jk 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JAKOBUSBRIEF 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("JAKOBUS 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("JAK 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("JAS 1:1").osis()).toEqual("Jas.1.1")
+		expect(p.parse("JAKOBUSBRIEF 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JAKOBUSBRIEF 1:1'")
+		expect(p.parse("JAKOBUS 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JAKOBUS 1:1'")
+		expect(p.parse("JAK 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JAK 1:1'")
+		expect(p.parse("JAS 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JAS 1:1'")
+		expect(p.parse("JK 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JK 1:1'")
 		`
 		true
 describe "Localized book 2Pet (de)", ->
@@ -1660,23 +1866,33 @@ describe "Localized book 2Pet (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Pet (de)", ->
 		`
-		expect(p.parse("Zweiten Petrus 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("Zweites Petrus 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("Zweite Petrus 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2. Petrus 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2 Petrus 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2. Petr 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2 Petr 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2Pet 1:1").osis()).toEqual("2Pet.1.1")
+		expect(p.parse("Zweiten Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'Zweiten Petrus 1:1'")
+		expect(p.parse("Zweiter Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'Zweiter Petrus 1:1'")
+		expect(p.parse("Zweites Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'Zweites Petrus 1:1'")
+		expect(p.parse("Zweite Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'Zweite Petrus 1:1'")
+		expect(p.parse("2. Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. Petrus 1:1'")
+		expect(p.parse("2 Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 Petrus 1:1'")
+		expect(p.parse("2. Petr 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. Petr 1:1'")
+		expect(p.parse("2 Petr 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 Petr 1:1'")
+		expect(p.parse("2. Pet 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. Pet 1:1'")
+		expect(p.parse("2 Pet 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 Pet 1:1'")
+		expect(p.parse("2. Pt 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. Pt 1:1'")
+		expect(p.parse("2 Pt 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 Pt 1:1'")
+		expect(p.parse("2Pet 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2Pet 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITEN PETRUS 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("ZWEITES PETRUS 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("ZWEITE PETRUS 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2. PETRUS 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2 PETRUS 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2. PETR 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2 PETR 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2PET 1:1").osis()).toEqual("2Pet.1.1")
+		expect(p.parse("ZWEITEN PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'ZWEITEN PETRUS 1:1'")
+		expect(p.parse("ZWEITER PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'ZWEITER PETRUS 1:1'")
+		expect(p.parse("ZWEITES PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'ZWEITES PETRUS 1:1'")
+		expect(p.parse("ZWEITE PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'ZWEITE PETRUS 1:1'")
+		expect(p.parse("2. PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. PETRUS 1:1'")
+		expect(p.parse("2 PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 PETRUS 1:1'")
+		expect(p.parse("2. PETR 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. PETR 1:1'")
+		expect(p.parse("2 PETR 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 PETR 1:1'")
+		expect(p.parse("2. PET 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. PET 1:1'")
+		expect(p.parse("2 PET 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 PET 1:1'")
+		expect(p.parse("2. PT 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. PT 1:1'")
+		expect(p.parse("2 PT 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 PT 1:1'")
+		expect(p.parse("2PET 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2PET 1:1'")
 		`
 		true
 describe "Localized book 1Pet (de)", ->
@@ -1687,23 +1903,33 @@ describe "Localized book 1Pet (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Pet (de)", ->
 		`
-		expect(p.parse("Ersten Petrus 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("Erstes Petrus 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("Erste Petrus 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1. Petrus 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1 Petrus 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1. Petr 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1 Petr 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1Pet 1:1").osis()).toEqual("1Pet.1.1")
+		expect(p.parse("Ersten Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'Ersten Petrus 1:1'")
+		expect(p.parse("Erster Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'Erster Petrus 1:1'")
+		expect(p.parse("Erstes Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'Erstes Petrus 1:1'")
+		expect(p.parse("Erste Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'Erste Petrus 1:1'")
+		expect(p.parse("1. Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. Petrus 1:1'")
+		expect(p.parse("1 Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 Petrus 1:1'")
+		expect(p.parse("1. Petr 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. Petr 1:1'")
+		expect(p.parse("1 Petr 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 Petr 1:1'")
+		expect(p.parse("1. Pet 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. Pet 1:1'")
+		expect(p.parse("1 Pet 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 Pet 1:1'")
+		expect(p.parse("1. Pt 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. Pt 1:1'")
+		expect(p.parse("1 Pt 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 Pt 1:1'")
+		expect(p.parse("1Pet 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1Pet 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTEN PETRUS 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("ERSTES PETRUS 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("ERSTE PETRUS 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1. PETRUS 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1 PETRUS 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1. PETR 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1 PETR 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1PET 1:1").osis()).toEqual("1Pet.1.1")
+		expect(p.parse("ERSTEN PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'ERSTEN PETRUS 1:1'")
+		expect(p.parse("ERSTER PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'ERSTER PETRUS 1:1'")
+		expect(p.parse("ERSTES PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'ERSTES PETRUS 1:1'")
+		expect(p.parse("ERSTE PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'ERSTE PETRUS 1:1'")
+		expect(p.parse("1. PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. PETRUS 1:1'")
+		expect(p.parse("1 PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 PETRUS 1:1'")
+		expect(p.parse("1. PETR 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. PETR 1:1'")
+		expect(p.parse("1 PETR 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 PETR 1:1'")
+		expect(p.parse("1. PET 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. PET 1:1'")
+		expect(p.parse("1 PET 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 PET 1:1'")
+		expect(p.parse("1. PT 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. PT 1:1'")
+		expect(p.parse("1 PT 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 PT 1:1'")
+		expect(p.parse("1PET 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1PET 1:1'")
 		`
 		true
 describe "Localized book Jude (de)", ->
@@ -1714,13 +1940,13 @@ describe "Localized book Jude (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Jude (de)", ->
 		`
-		expect(p.parse("Judas 1:1").osis()).toEqual("Jude.1.1")
-		expect(p.parse("Jude 1:1").osis()).toEqual("Jude.1.1")
-		expect(p.parse("Jud 1:1").osis()).toEqual("Jude.1.1")
+		expect(p.parse("Judas 1:1").osis()).toEqual("Jude.1.1", "parsing: 'Judas 1:1'")
+		expect(p.parse("Jude 1:1").osis()).toEqual("Jude.1.1", "parsing: 'Jude 1:1'")
+		expect(p.parse("Jud 1:1").osis()).toEqual("Jude.1.1", "parsing: 'Jud 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JUDAS 1:1").osis()).toEqual("Jude.1.1")
-		expect(p.parse("JUDE 1:1").osis()).toEqual("Jude.1.1")
-		expect(p.parse("JUD 1:1").osis()).toEqual("Jude.1.1")
+		expect(p.parse("JUDAS 1:1").osis()).toEqual("Jude.1.1", "parsing: 'JUDAS 1:1'")
+		expect(p.parse("JUDE 1:1").osis()).toEqual("Jude.1.1", "parsing: 'JUDE 1:1'")
+		expect(p.parse("JUD 1:1").osis()).toEqual("Jude.1.1", "parsing: 'JUD 1:1'")
 		`
 		true
 describe "Localized book Tob (de)", ->
@@ -1731,9 +1957,9 @@ describe "Localized book Tob (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Tob (de)", ->
 		`
-		expect(p.parse("Tobias 1:1").osis()).toEqual("Tob.1.1")
-		expect(p.parse("Tobit 1:1").osis()).toEqual("Tob.1.1")
-		expect(p.parse("Tob 1:1").osis()).toEqual("Tob.1.1")
+		expect(p.parse("Tobias 1:1").osis()).toEqual("Tob.1.1", "parsing: 'Tobias 1:1'")
+		expect(p.parse("Tobit 1:1").osis()).toEqual("Tob.1.1", "parsing: 'Tobit 1:1'")
+		expect(p.parse("Tob 1:1").osis()).toEqual("Tob.1.1", "parsing: 'Tob 1:1'")
 		`
 		true
 describe "Localized book Jdt (de)", ->
@@ -1744,8 +1970,8 @@ describe "Localized book Jdt (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Jdt (de)", ->
 		`
-		expect(p.parse("Judit 1:1").osis()).toEqual("Jdt.1.1")
-		expect(p.parse("Jdt 1:1").osis()).toEqual("Jdt.1.1")
+		expect(p.parse("Judit 1:1").osis()).toEqual("Jdt.1.1", "parsing: 'Judit 1:1'")
+		expect(p.parse("Jdt 1:1").osis()).toEqual("Jdt.1.1", "parsing: 'Jdt 1:1'")
 		`
 		true
 describe "Localized book Bar (de)", ->
@@ -1756,8 +1982,8 @@ describe "Localized book Bar (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Bar (de)", ->
 		`
-		expect(p.parse("Baruch 1:1").osis()).toEqual("Bar.1.1")
-		expect(p.parse("Bar 1:1").osis()).toEqual("Bar.1.1")
+		expect(p.parse("Baruch 1:1").osis()).toEqual("Bar.1.1", "parsing: 'Baruch 1:1'")
+		expect(p.parse("Bar 1:1").osis()).toEqual("Bar.1.1", "parsing: 'Bar 1:1'")
 		`
 		true
 describe "Localized book Sus (de)", ->
@@ -1768,10 +1994,8 @@ describe "Localized book Sus (de)", ->
 		p.include_apocrypha true
 	it "should handle book: Sus (de)", ->
 		`
-		expect(p.parse("Susanna und die Alten 1:1").osis()).toEqual("Sus.1.1")
-		expect(p.parse("Susanna im Bade 1:1").osis()).toEqual("Sus.1.1")
-		expect(p.parse("Susanna 1:1").osis()).toEqual("Sus.1.1")
-		expect(p.parse("Sus 1:1").osis()).toEqual("Sus.1.1")
+		expect(p.parse("Susanna 1:1").osis()).toEqual("Sus.1.1", "parsing: 'Susanna 1:1'")
+		expect(p.parse("Sus 1:1").osis()).toEqual("Sus.1.1", "parsing: 'Sus 1:1'")
 		`
 		true
 describe "Localized book 2Macc (de)", ->
@@ -1782,19 +2006,27 @@ describe "Localized book 2Macc (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 2Macc (de)", ->
 		`
-		expect(p.parse("Zweiten Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("Zweiten Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("Zweites Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("Zweites Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("Zweite Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("Zweite Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2. Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2. Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2 Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2 Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2. Makk 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2 Makk 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2Macc 1:1").osis()).toEqual("2Macc.1.1")
+		expect(p.parse("Zweiten Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiten Makkabaeer 1:1'")
+		expect(p.parse("Zweiter Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiter Makkabaeer 1:1'")
+		expect(p.parse("Zweites Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweites Makkabaeer 1:1'")
+		expect(p.parse("Zweite Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweite Makkabaeer 1:1'")
+		expect(p.parse("Zweiten Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiten Makkabaer 1:1'")
+		expect(p.parse("Zweiten Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiten Makkabäer 1:1'")
+		expect(p.parse("Zweiter Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiter Makkabaer 1:1'")
+		expect(p.parse("Zweiter Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiter Makkabäer 1:1'")
+		expect(p.parse("Zweites Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweites Makkabaer 1:1'")
+		expect(p.parse("Zweites Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweites Makkabäer 1:1'")
+		expect(p.parse("Zweite Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweite Makkabaer 1:1'")
+		expect(p.parse("Zweite Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweite Makkabäer 1:1'")
+		expect(p.parse("2. Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2. Makkabaeer 1:1'")
+		expect(p.parse("2 Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2 Makkabaeer 1:1'")
+		expect(p.parse("2. Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2. Makkabaer 1:1'")
+		expect(p.parse("2. Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2. Makkabäer 1:1'")
+		expect(p.parse("2 Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2 Makkabaer 1:1'")
+		expect(p.parse("2 Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2 Makkabäer 1:1'")
+		expect(p.parse("2. Makk 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2. Makk 1:1'")
+		expect(p.parse("2 Makk 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2 Makk 1:1'")
+		expect(p.parse("2Macc 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2Macc 1:1'")
 		`
 		true
 describe "Localized book 3Macc (de)", ->
@@ -1805,19 +2037,27 @@ describe "Localized book 3Macc (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 3Macc (de)", ->
 		`
-		expect(p.parse("Dritten Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("Dritten Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("Drittes Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("Drittes Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("Dritte Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("Dritte Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3. Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3. Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3 Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3 Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3. Makk 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3 Makk 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3Macc 1:1").osis()).toEqual("3Macc.1.1")
+		expect(p.parse("Dritten Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritten Makkabaeer 1:1'")
+		expect(p.parse("Dritter Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritter Makkabaeer 1:1'")
+		expect(p.parse("Drittes Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Drittes Makkabaeer 1:1'")
+		expect(p.parse("Dritte Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritte Makkabaeer 1:1'")
+		expect(p.parse("Dritten Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritten Makkabaer 1:1'")
+		expect(p.parse("Dritten Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritten Makkabäer 1:1'")
+		expect(p.parse("Dritter Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritter Makkabaer 1:1'")
+		expect(p.parse("Dritter Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritter Makkabäer 1:1'")
+		expect(p.parse("Drittes Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Drittes Makkabaer 1:1'")
+		expect(p.parse("Drittes Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Drittes Makkabäer 1:1'")
+		expect(p.parse("Dritte Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritte Makkabaer 1:1'")
+		expect(p.parse("Dritte Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritte Makkabäer 1:1'")
+		expect(p.parse("3. Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3. Makkabaeer 1:1'")
+		expect(p.parse("3 Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3 Makkabaeer 1:1'")
+		expect(p.parse("3. Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3. Makkabaer 1:1'")
+		expect(p.parse("3. Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3. Makkabäer 1:1'")
+		expect(p.parse("3 Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3 Makkabaer 1:1'")
+		expect(p.parse("3 Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3 Makkabäer 1:1'")
+		expect(p.parse("3. Makk 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3. Makk 1:1'")
+		expect(p.parse("3 Makk 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3 Makk 1:1'")
+		expect(p.parse("3Macc 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3Macc 1:1'")
 		`
 		true
 describe "Localized book 4Macc (de)", ->
@@ -1828,19 +2068,24 @@ describe "Localized book 4Macc (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 4Macc (de)", ->
 		`
-		expect(p.parse("Vierten Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("Vierten Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("Viertes Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("Viertes Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("Vierte Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("Vierte Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4. Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4. Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4 Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4 Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4. Makk 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4 Makk 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4Macc 1:1").osis()).toEqual("4Macc.1.1")
+		expect(p.parse("Vierten Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierten Makkabaeer 1:1'")
+		expect(p.parse("Viertes Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Viertes Makkabaeer 1:1'")
+		expect(p.parse("Vierte Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierte Makkabaeer 1:1'")
+		expect(p.parse("Vierten Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierten Makkabaer 1:1'")
+		expect(p.parse("Vierten Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierten Makkabäer 1:1'")
+		expect(p.parse("Viertes Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Viertes Makkabaer 1:1'")
+		expect(p.parse("Viertes Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Viertes Makkabäer 1:1'")
+		expect(p.parse("Vierte Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierte Makkabaer 1:1'")
+		expect(p.parse("Vierte Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierte Makkabäer 1:1'")
+		expect(p.parse("4. Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4. Makkabaeer 1:1'")
+		expect(p.parse("4 Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4 Makkabaeer 1:1'")
+		expect(p.parse("4. Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4. Makkabaer 1:1'")
+		expect(p.parse("4. Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4. Makkabäer 1:1'")
+		expect(p.parse("4 Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4 Makkabaer 1:1'")
+		expect(p.parse("4 Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4 Makkabäer 1:1'")
+		expect(p.parse("4. Makk 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4. Makk 1:1'")
+		expect(p.parse("4 Makk 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4 Makk 1:1'")
+		expect(p.parse("4Macc 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4Macc 1:1'")
 		`
 		true
 describe "Localized book 1Macc (de)", ->
@@ -1851,45 +2096,27 @@ describe "Localized book 1Macc (de)", ->
 		p.include_apocrypha true
 	it "should handle book: 1Macc (de)", ->
 		`
-		expect(p.parse("Ersten Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("Ersten Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("Erstes Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("Erstes Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("Erste Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("Erste Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1. Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1. Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1 Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1 Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1. Makk 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1 Makk 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1Macc 1:1").osis()).toEqual("1Macc.1.1")
-		`
-		true
-describe "Localized book Ezra,Esth (de)", ->
-	p = {}
-	beforeEach ->
-		p = new bcv_parser
-		p.set_options book_alone_strategy: "ignore",book_sequence_strategy: "ignore",osis_compaction_strategy: "bc",captive_end_digits_strategy: "delete"
-		p.include_apocrypha true
-	it "should handle book: Ezra,Esth (de)", ->
-		`
-		expect(p.parse("Es 1:1").osis()).toEqual("Ezra.1.1")
-		p.include_apocrypha(false)
-		expect(p.parse("ES 1:1").osis()).toEqual("Ezra.1.1")
-		`
-		true
-describe "Localized book Phil,Phlm (de)", ->
-	p = {}
-	beforeEach ->
-		p = new bcv_parser
-		p.set_options book_alone_strategy: "ignore",book_sequence_strategy: "ignore",osis_compaction_strategy: "bc",captive_end_digits_strategy: "delete"
-		p.include_apocrypha true
-	it "should handle book: Phil,Phlm (de)", ->
-		`
-		expect(p.parse("Ph 1:1").osis()).toEqual("Phil.1.1")
-		p.include_apocrypha(false)
-		expect(p.parse("PH 1:1").osis()).toEqual("Phil.1.1")
+		expect(p.parse("Ersten Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Ersten Makkabaeer 1:1'")
+		expect(p.parse("Erster Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erster Makkabaeer 1:1'")
+		expect(p.parse("Erstes Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erstes Makkabaeer 1:1'")
+		expect(p.parse("Erste Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erste Makkabaeer 1:1'")
+		expect(p.parse("Ersten Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Ersten Makkabaer 1:1'")
+		expect(p.parse("Ersten Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Ersten Makkabäer 1:1'")
+		expect(p.parse("Erster Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erster Makkabaer 1:1'")
+		expect(p.parse("Erster Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erster Makkabäer 1:1'")
+		expect(p.parse("Erstes Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erstes Makkabaer 1:1'")
+		expect(p.parse("Erstes Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erstes Makkabäer 1:1'")
+		expect(p.parse("Erste Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erste Makkabaer 1:1'")
+		expect(p.parse("Erste Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erste Makkabäer 1:1'")
+		expect(p.parse("1. Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1. Makkabaeer 1:1'")
+		expect(p.parse("1 Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1 Makkabaeer 1:1'")
+		expect(p.parse("1. Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1. Makkabaer 1:1'")
+		expect(p.parse("1. Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1. Makkabäer 1:1'")
+		expect(p.parse("1 Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1 Makkabaer 1:1'")
+		expect(p.parse("1 Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1 Makkabäer 1:1'")
+		expect(p.parse("1. Makk 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1. Makk 1:1'")
+		expect(p.parse("1 Makk 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1 Makk 1:1'")
+		expect(p.parse("1Macc 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1Macc 1:1'")
 		`
 		true
 
@@ -1904,70 +2131,68 @@ describe "Miscellaneous tests", ->
 		expect(p.languages).toEqual ["de"]
 
 	it "should handle ranges (de)", ->
-		expect(p.parse("Titus 1:1 bis 2").osis()).toEqual "Titus.1.1-Titus.1.2"
-		expect(p.parse("Matt 1bis2").osis()).toEqual "Matt.1-Matt.2"
-		expect(p.parse("Phlm 2 BIS 3").osis()).toEqual "Phlm.1.2-Phlm.1.3"
+		expect(p.parse("Titus 1:1 bis 2").osis()).toEqual("Titus.1.1-Titus.1.2", "parsing: 'Titus 1:1 bis 2'")
+		expect(p.parse("Matt 1bis2").osis()).toEqual("Matt.1-Matt.2", "parsing: 'Matt 1bis2'")
+		expect(p.parse("Phlm 2 BIS 3").osis()).toEqual("Phlm.1.2-Phlm.1.3", "parsing: 'Phlm 2 BIS 3'")
 	it "should handle chapters (de)", ->
-		expect(p.parse("Titus 1:1, Kapitels 2").osis()).toEqual "Titus.1.1,Titus.2"
-		expect(p.parse("Matt 3:4 KAPITELS 6").osis()).toEqual "Matt.3.4,Matt.6"
-		expect(p.parse("Titus 1:1, Kapiteln 2").osis()).toEqual "Titus.1.1,Titus.2"
-		expect(p.parse("Matt 3:4 KAPITELN 6").osis()).toEqual "Matt.3.4,Matt.6"
-		expect(p.parse("Titus 1:1, Kapitel 2").osis()).toEqual "Titus.1.1,Titus.2"
-		expect(p.parse("Matt 3:4 KAPITEL 6").osis()).toEqual "Matt.3.4,Matt.6"
-		expect(p.parse("Titus 1:1, Kap. 2").osis()).toEqual "Titus.1.1,Titus.2"
-		expect(p.parse("Matt 3:4 KAP. 6").osis()).toEqual "Matt.3.4,Matt.6"
-		expect(p.parse("Titus 1:1, Kap 2").osis()).toEqual "Titus.1.1,Titus.2"
-		expect(p.parse("Matt 3:4 KAP 6").osis()).toEqual "Matt.3.4,Matt.6"
+		expect(p.parse("Titus 1:1, Kapiteln 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kapiteln 2'")
+		expect(p.parse("Matt 3:4 KAPITELN 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAPITELN 6'")
+		expect(p.parse("Titus 1:1, Kapiteln 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kapiteln 2'")
+		expect(p.parse("Matt 3:4 KAPITELN 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAPITELN 6'")
+		expect(p.parse("Titus 1:1, Kapitel 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kapitel 2'")
+		expect(p.parse("Matt 3:4 KAPITEL 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAPITEL 6'")
+		expect(p.parse("Titus 1:1, Kap. 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kap. 2'")
+		expect(p.parse("Matt 3:4 KAP. 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAP. 6'")
+		expect(p.parse("Titus 1:1, Kap 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kap 2'")
+		expect(p.parse("Matt 3:4 KAP 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAP 6'")
 	it "should handle verses (de)", ->
-		expect(p.parse("Exod 1:1 Verses 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VERSES 6").osis()).toEqual "Phlm.1.6"
-		expect(p.parse("Exod 1:1 Versen 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VERSEN 6").osis()).toEqual "Phlm.1.6"
-		expect(p.parse("Exod 1:1 Verse 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VERSE 6").osis()).toEqual "Phlm.1.6"
-		expect(p.parse("Exod 1:1 Vers. 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VERS. 6").osis()).toEqual "Phlm.1.6"
-		expect(p.parse("Exod 1:1 Vers 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VERS 6").osis()).toEqual "Phlm.1.6"
-		expect(p.parse("Exod 1:1 Vers 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VERS 6").osis()).toEqual "Phlm.1.6"
-		expect(p.parse("Exod 1:1 Ver. 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VER. 6").osis()).toEqual "Phlm.1.6"
-		expect(p.parse("Exod 1:1 Ver 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VER 6").osis()).toEqual "Phlm.1.6"
-		expect(p.parse("Exod 1:1 Vs. 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VS. 6").osis()).toEqual "Phlm.1.6"
-		expect(p.parse("Exod 1:1 Vs 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm VS 6").osis()).toEqual "Phlm.1.6"
+		expect(p.parse("Exod 1:1 Versen 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Versen 3'")
+		expect(p.parse("Phlm VERSEN 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERSEN 6'")
+		expect(p.parse("Exod 1:1 Verses 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Verses 3'")
+		expect(p.parse("Phlm VERSES 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERSES 6'")
+		expect(p.parse("Exod 1:1 Verse 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Verse 3'")
+		expect(p.parse("Phlm VERSE 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERSE 6'")
+		expect(p.parse("Exod 1:1 Vers. 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vers. 3'")
+		expect(p.parse("Phlm VERS. 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERS. 6'")
+		expect(p.parse("Exod 1:1 Vers 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vers 3'")
+		expect(p.parse("Phlm VERS 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERS 6'")
+		expect(p.parse("Exod 1:1 Vers 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vers 3'")
+		expect(p.parse("Phlm VERS 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERS 6'")
+		expect(p.parse("Exod 1:1 Vs. 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vs. 3'")
+		expect(p.parse("Phlm VS. 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VS. 6'")
+		expect(p.parse("Exod 1:1 Vs 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vs 3'")
+		expect(p.parse("Phlm VS 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VS 6'")
 	it "should handle 'and' (de)", ->
-		expect(p.parse("Exod 1:1 und 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 UND 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
-		expect(p.parse("Exod 1:1 u. 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 U. 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
-		expect(p.parse("Exod 1:1 u 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 U 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
-		expect(p.parse("Exod 1:1 & 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 & 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
-		expect(p.parse("Exod 1:1 vgl. 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 VGL. 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
-		expect(p.parse("Exod 1:1 vgl 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 VGL 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
-		expect(p.parse("Exod 1:1 sowie 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 SOWIE 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
-		expect(p.parse("Exod 1:1 und auch 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 UND AUCH 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
-		expect(p.parse("Exod 1:1 und siehe auch 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 UND SIEHE AUCH 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
-		expect(p.parse("Exod 1:1 siehe auch 3").osis()).toEqual "Exod.1.1,Exod.1.3"
-		expect(p.parse("Phlm 2 SIEHE AUCH 6").osis()).toEqual "Phlm.1.2,Phlm.1.6"
+		expect(p.parse("Exod 1:1 und siehe auch 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 und siehe auch 3'")
+		expect(p.parse("Phlm 2 UND SIEHE AUCH 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 UND SIEHE AUCH 6'")
+		expect(p.parse("Exod 1:1 und siehe 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 und siehe 3'")
+		expect(p.parse("Phlm 2 UND SIEHE 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 UND SIEHE 6'")
+		expect(p.parse("Exod 1:1 und auch 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 und auch 3'")
+		expect(p.parse("Phlm 2 UND AUCH 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 UND AUCH 6'")
+		expect(p.parse("Exod 1:1 sowie auch 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 sowie auch 3'")
+		expect(p.parse("Phlm 2 SOWIE AUCH 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 SOWIE AUCH 6'")
+		expect(p.parse("Exod 1:1 siehe auch 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 siehe auch 3'")
+		expect(p.parse("Phlm 2 SIEHE AUCH 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 SIEHE AUCH 6'")
+		expect(p.parse("Exod 1:1 siehe 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 siehe 3'")
+		expect(p.parse("Phlm 2 SIEHE 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 SIEHE 6'")
+		expect(p.parse("Exod 1:1 sowie 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 sowie 3'")
+		expect(p.parse("Phlm 2 SOWIE 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 SOWIE 6'")
+		expect(p.parse("Exod 1:1 u. 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 u. 3'")
+		expect(p.parse("Phlm 2 U. 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 U. 6'")
+		expect(p.parse("Exod 1:1 u 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 u 3'")
+		expect(p.parse("Phlm 2 U 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 U 6'")
+		expect(p.parse("Exod 1:1 & 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 & 3'")
+		expect(p.parse("Phlm 2 & 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 & 6'")
+		expect(p.parse("Exod 1:1 vgl. 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 vgl. 3'")
+		expect(p.parse("Phlm 2 VGL. 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 VGL. 6'")
+		expect(p.parse("Exod 1:1 vgl 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 vgl 3'")
+		expect(p.parse("Phlm 2 VGL 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 VGL 6'")
 	it "should handle titles (de)", ->
-		expect(p.parse("Ps 3 Titel, 4:2, 5:Titel").osis()).toEqual "Ps.3.1,Ps.4.2,Ps.5.1"
-		expect(p.parse("PS 3 TITEL, 4:2, 5:TITEL").osis()).toEqual "Ps.3.1,Ps.4.2,Ps.5.1"
+		expect(p.parse("Ps 3 Titel, 4:2, 5:Titel").osis()).toEqual("Ps.3.1,Ps.4.2,Ps.5.1", "parsing: 'Ps 3 Titel, 4:2, 5:Titel'")
+		expect(p.parse("PS 3 TITEL, 4:2, 5:TITEL").osis()).toEqual("Ps.3.1,Ps.4.2,Ps.5.1", "parsing: 'PS 3 TITEL, 4:2, 5:TITEL'")
 	it "should handle 'ff' (de)", ->
-		expect(p.parse("Rev 3ff, 4:2ff").osis()).toEqual "Rev.3-Rev.22,Rev.4.2-Rev.4.11"
-		expect(p.parse("REV 3 FF, 4:2 FF").osis()).toEqual "Rev.3-Rev.22,Rev.4.2-Rev.4.11"
-		expect(p.parse("Rev 3f, 4:2f").osis()).toEqual "Rev.3-Rev.22,Rev.4.2-Rev.4.11"
-		expect(p.parse("REV 3 F, 4:2 F").osis()).toEqual "Rev.3-Rev.22,Rev.4.2-Rev.4.11"
+		expect(p.parse("Rev 3ff, 4:2ff").osis()).toEqual("Rev.3-Rev.22,Rev.4.2-Rev.4.11", "parsing: 'Rev 3ff, 4:2ff'")
+		expect(p.parse("REV 3 FF, 4:2 FF").osis()).toEqual("Rev.3-Rev.22,Rev.4.2-Rev.4.11", "parsing: 'REV 3 FF, 4:2 FF'")
 	it "should handle translations (de)", ->
 		expect(p.parse("Lev 1 (ELB)").osis_and_translations()).toEqual [["Lev.1", "ELB"]]
 		expect(p.parse("lev 1 elb").osis_and_translations()).toEqual [["Lev.1", "ELB"]]
@@ -1983,8 +2208,8 @@ describe "Miscellaneous tests", ->
 		expect(p.parse("lev 1 sch2000").osis_and_translations()).toEqual [["Lev.1", "SCH2000"]]
 	it "should handle book ranges (de)", ->
 		p.set_options {book_alone_strategy: "full", book_range_strategy: "include"}
-		expect(p.parse("Erstes bis Drittes  Johannes").osis()).toEqual "1John.1-3John.1"
+		expect(p.parse("Ersten bis Dritten  Johannes").osis()).toEqual("1John.1-3John.1", "parsing: 'Ersten bis Dritten  Johannes'")
 	it "should handle boundaries (de)", ->
 		p.set_options {book_alone_strategy: "full"}
-		expect(p.parse("\u2014Matt\u2014").osis()).toEqual "Matt.1-Matt.28"
-		expect(p.parse("\u201cMatt 1:1\u201d").osis()).toEqual "Matt.1.1"
+		expect(p.parse("\u2014Matt\u2014").osis()).toEqual("Matt.1-Matt.28", "parsing: '\u2014Matt\u2014'")
+		expect(p.parse("\u201cMatt 1:1\u201d").osis()).toEqual("Matt.1.1", "parsing: '\u201cMatt 1:1\u201d'")

--- a/src/de/translations.coffee
+++ b/src/de/translations.coffee
@@ -1,6 +1,6 @@
 # When adding a new translation, add it both here and bcv_parser::translations.aliases
 bcv_parser::regexps.translations = ///(?:
-	  (?:LUTH(?:1545|ER)|SCH(?:195|200)0|HFA|ELB)
+	  (?:LUTH(?:1545|ER)|SCH(?:200|195)0|HFA|ELB)
 	)\b///gi
 bcv_parser::translations = 
 	aliases:

--- a/test/js/de.spec.js
+++ b/test/js/de.spec.js
@@ -84,31 +84,45 @@
     });
     return it("should handle book: Gen (de)", function() {
       
-		expect(p.parse("Erste Buch Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. Buch Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 Buch Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Erste Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Genesis 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 Mose 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. Mos 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 Mos 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. Mo 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 Mo 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("Gen 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("Ersten Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Ersten Buch Mose 1:1'")
+		expect(p.parse("Erster Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erster Buch Mose 1:1'")
+		expect(p.parse("Erstes Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erstes Buch Mose 1:1'")
+		expect(p.parse("Erste Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erste Buch Mose 1:1'")
+		expect(p.parse("1. Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. Buch Mose 1:1'")
+		expect(p.parse("1 Buch Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 Buch Mose 1:1'")
+		expect(p.parse("Ersten Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Ersten Mose 1:1'")
+		expect(p.parse("Erster Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erster Mose 1:1'")
+		expect(p.parse("Erstes Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erstes Mose 1:1'")
+		expect(p.parse("Erste Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Erste Mose 1:1'")
+		expect(p.parse("1. Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. Mose 1:1'")
+		expect(p.parse("Genesis 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Genesis 1:1'")
+		expect(p.parse("1 Mose 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 Mose 1:1'")
+		expect(p.parse("1. Mos 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. Mos 1:1'")
+		expect(p.parse("1 Mos 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 Mos 1:1'")
+		expect(p.parse("1. Mo 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. Mo 1:1'")
+		expect(p.parse("1 Mo 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 Mo 1:1'")
+		expect(p.parse("Gen 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Gen 1:1'")
+		expect(p.parse("Gn 1:1").osis()).toEqual("Gen.1.1", "parsing: 'Gn 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTE BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 BUCH MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("ERSTE MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("GENESIS 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 MOSE 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. MOS 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 MOS 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1. MO 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("1 MO 1:1").osis()).toEqual("Gen.1.1")
-		expect(p.parse("GEN 1:1").osis()).toEqual("Gen.1.1")
+		expect(p.parse("ERSTEN BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTEN BUCH MOSE 1:1'")
+		expect(p.parse("ERSTER BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTER BUCH MOSE 1:1'")
+		expect(p.parse("ERSTES BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTES BUCH MOSE 1:1'")
+		expect(p.parse("ERSTE BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTE BUCH MOSE 1:1'")
+		expect(p.parse("1. BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. BUCH MOSE 1:1'")
+		expect(p.parse("1 BUCH MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 BUCH MOSE 1:1'")
+		expect(p.parse("ERSTEN MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTEN MOSE 1:1'")
+		expect(p.parse("ERSTER MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTER MOSE 1:1'")
+		expect(p.parse("ERSTES MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTES MOSE 1:1'")
+		expect(p.parse("ERSTE MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: 'ERSTE MOSE 1:1'")
+		expect(p.parse("1. MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. MOSE 1:1'")
+		expect(p.parse("GENESIS 1:1").osis()).toEqual("Gen.1.1", "parsing: 'GENESIS 1:1'")
+		expect(p.parse("1 MOSE 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 MOSE 1:1'")
+		expect(p.parse("1. MOS 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. MOS 1:1'")
+		expect(p.parse("1 MOS 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 MOS 1:1'")
+		expect(p.parse("1. MO 1:1").osis()).toEqual("Gen.1.1", "parsing: '1. MO 1:1'")
+		expect(p.parse("1 MO 1:1").osis()).toEqual("Gen.1.1", "parsing: '1 MO 1:1'")
+		expect(p.parse("GEN 1:1").osis()).toEqual("Gen.1.1", "parsing: 'GEN 1:1'")
+		expect(p.parse("GN 1:1").osis()).toEqual("Gen.1.1", "parsing: 'GN 1:1'")
 		;
       return true;
     });
@@ -129,33 +143,45 @@
     });
     return it("should handle book: Exod (de)", function() {
       
-		expect(p.parse("Zweite Buch Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. Buch Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 Buch Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Zweite Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 Mose 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. Mos 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Exodus 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 Mos 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. Mo 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 Mo 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Exod 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("Ex 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("Zweiten Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweiten Buch Mose 1:1'")
+		expect(p.parse("Zweiter Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweiter Buch Mose 1:1'")
+		expect(p.parse("Zweites Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweites Buch Mose 1:1'")
+		expect(p.parse("Zweite Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweite Buch Mose 1:1'")
+		expect(p.parse("2. Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. Buch Mose 1:1'")
+		expect(p.parse("Zweiten Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweiten Mose 1:1'")
+		expect(p.parse("Zweiter Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweiter Mose 1:1'")
+		expect(p.parse("Zweites Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweites Mose 1:1'")
+		expect(p.parse("2 Buch Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 Buch Mose 1:1'")
+		expect(p.parse("Zweite Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Zweite Mose 1:1'")
+		expect(p.parse("2. Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. Mose 1:1'")
+		expect(p.parse("2 Mose 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 Mose 1:1'")
+		expect(p.parse("2. Mos 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. Mos 1:1'")
+		expect(p.parse("Exodus 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Exodus 1:1'")
+		expect(p.parse("2 Mos 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 Mos 1:1'")
+		expect(p.parse("2. Mo 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. Mo 1:1'")
+		expect(p.parse("2 Mo 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 Mo 1:1'")
+		expect(p.parse("Exod 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Exod 1:1'")
+		expect(p.parse("Ex 1:1").osis()).toEqual("Exod.1.1", "parsing: 'Ex 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITE BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 BUCH MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("ZWEITE MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 MOSE 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. MOS 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("EXODUS 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 MOS 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2. MO 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("2 MO 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("EXOD 1:1").osis()).toEqual("Exod.1.1")
-		expect(p.parse("EX 1:1").osis()).toEqual("Exod.1.1")
+		expect(p.parse("ZWEITEN BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITEN BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITER BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITER BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITES BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITES BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITE BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITE BUCH MOSE 1:1'")
+		expect(p.parse("2. BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITEN MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITEN MOSE 1:1'")
+		expect(p.parse("ZWEITER MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITER MOSE 1:1'")
+		expect(p.parse("ZWEITES MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITES MOSE 1:1'")
+		expect(p.parse("2 BUCH MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 BUCH MOSE 1:1'")
+		expect(p.parse("ZWEITE MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: 'ZWEITE MOSE 1:1'")
+		expect(p.parse("2. MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. MOSE 1:1'")
+		expect(p.parse("2 MOSE 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 MOSE 1:1'")
+		expect(p.parse("2. MOS 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. MOS 1:1'")
+		expect(p.parse("EXODUS 1:1").osis()).toEqual("Exod.1.1", "parsing: 'EXODUS 1:1'")
+		expect(p.parse("2 MOS 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 MOS 1:1'")
+		expect(p.parse("2. MO 1:1").osis()).toEqual("Exod.1.1", "parsing: '2. MO 1:1'")
+		expect(p.parse("2 MO 1:1").osis()).toEqual("Exod.1.1", "parsing: '2 MO 1:1'")
+		expect(p.parse("EXOD 1:1").osis()).toEqual("Exod.1.1", "parsing: 'EXOD 1:1'")
+		expect(p.parse("EX 1:1").osis()).toEqual("Exod.1.1", "parsing: 'EX 1:1'")
 		;
       return true;
     });
@@ -176,8 +202,10 @@
     });
     return it("should handle book: Bel (de)", function() {
       
-		expect(p.parse("Bel und Vom Drachen 1:1").osis()).toEqual("Bel.1.1")
-		expect(p.parse("Bel 1:1").osis()).toEqual("Bel.1.1")
+		expect(p.parse("Bel und Vom Drachen 1:1").osis()).toEqual("Bel.1.1", "parsing: 'Bel und Vom Drachen 1:1'")
+		expect(p.parse("Bel und der Drache 1:1").osis()).toEqual("Bel.1.1", "parsing: 'Bel und der Drache 1:1'")
+		expect(p.parse("Bel und de Drache 1:1").osis()).toEqual("Bel.1.1", "parsing: 'Bel und de Drache 1:1'")
+		expect(p.parse("Bel 1:1").osis()).toEqual("Bel.1.1", "parsing: 'Bel 1:1'")
 		;
       return true;
     });
@@ -198,31 +226,45 @@
     });
     return it("should handle book: Lev (de)", function() {
       
-		expect(p.parse("Dritte Buch Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. Buch Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 Buch Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Dritte Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Levitikus 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 Mose 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. Mos 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 Mos 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. Mo 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 Mo 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("Lev 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("Dritten Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritten Buch Mose 1:1'")
+		expect(p.parse("Dritter Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritter Buch Mose 1:1'")
+		expect(p.parse("Drittes Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Drittes Buch Mose 1:1'")
+		expect(p.parse("Dritte Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritte Buch Mose 1:1'")
+		expect(p.parse("3. Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. Buch Mose 1:1'")
+		expect(p.parse("Dritten Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritten Mose 1:1'")
+		expect(p.parse("Dritter Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritter Mose 1:1'")
+		expect(p.parse("Drittes Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Drittes Mose 1:1'")
+		expect(p.parse("3 Buch Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 Buch Mose 1:1'")
+		expect(p.parse("Dritte Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Dritte Mose 1:1'")
+		expect(p.parse("Levitikus 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Levitikus 1:1'")
+		expect(p.parse("3. Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. Mose 1:1'")
+		expect(p.parse("3 Mose 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 Mose 1:1'")
+		expect(p.parse("3. Mos 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. Mos 1:1'")
+		expect(p.parse("3 Mos 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 Mos 1:1'")
+		expect(p.parse("3. Mo 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. Mo 1:1'")
+		expect(p.parse("3 Mo 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 Mo 1:1'")
+		expect(p.parse("Lev 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Lev 1:1'")
+		expect(p.parse("Lv 1:1").osis()).toEqual("Lev.1.1", "parsing: 'Lv 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DRITTE BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 BUCH MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("DRITTE MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("LEVITIKUS 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 MOSE 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. MOS 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 MOS 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3. MO 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("3 MO 1:1").osis()).toEqual("Lev.1.1")
-		expect(p.parse("LEV 1:1").osis()).toEqual("Lev.1.1")
+		expect(p.parse("DRITTEN BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTEN BUCH MOSE 1:1'")
+		expect(p.parse("DRITTER BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTER BUCH MOSE 1:1'")
+		expect(p.parse("DRITTES BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTES BUCH MOSE 1:1'")
+		expect(p.parse("DRITTE BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTE BUCH MOSE 1:1'")
+		expect(p.parse("3. BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. BUCH MOSE 1:1'")
+		expect(p.parse("DRITTEN MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTEN MOSE 1:1'")
+		expect(p.parse("DRITTER MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTER MOSE 1:1'")
+		expect(p.parse("DRITTES MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTES MOSE 1:1'")
+		expect(p.parse("3 BUCH MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 BUCH MOSE 1:1'")
+		expect(p.parse("DRITTE MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: 'DRITTE MOSE 1:1'")
+		expect(p.parse("LEVITIKUS 1:1").osis()).toEqual("Lev.1.1", "parsing: 'LEVITIKUS 1:1'")
+		expect(p.parse("3. MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. MOSE 1:1'")
+		expect(p.parse("3 MOSE 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 MOSE 1:1'")
+		expect(p.parse("3. MOS 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. MOS 1:1'")
+		expect(p.parse("3 MOS 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 MOS 1:1'")
+		expect(p.parse("3. MO 1:1").osis()).toEqual("Lev.1.1", "parsing: '3. MO 1:1'")
+		expect(p.parse("3 MO 1:1").osis()).toEqual("Lev.1.1", "parsing: '3 MO 1:1'")
+		expect(p.parse("LEV 1:1").osis()).toEqual("Lev.1.1", "parsing: 'LEV 1:1'")
+		expect(p.parse("LV 1:1").osis()).toEqual("Lev.1.1", "parsing: 'LV 1:1'")
 		;
       return true;
     });
@@ -243,31 +285,41 @@
     });
     return it("should handle book: Num (de)", function() {
       
-		expect(p.parse("Vierte Buch Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. Buch Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 Buch Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Vierte Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 Mose 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. Mos 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Numeri 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 Mos 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. Mo 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 Mo 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("Num 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("Vierten Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Vierten Buch Mose 1:1'")
+		expect(p.parse("Viertes Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Viertes Buch Mose 1:1'")
+		expect(p.parse("Vierte Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Vierte Buch Mose 1:1'")
+		expect(p.parse("4. Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: '4. Buch Mose 1:1'")
+		expect(p.parse("Vierten Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Vierten Mose 1:1'")
+		expect(p.parse("Viertes Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Viertes Mose 1:1'")
+		expect(p.parse("4 Buch Mose 1:1").osis()).toEqual("Num.1.1", "parsing: '4 Buch Mose 1:1'")
+		expect(p.parse("Vierte Mose 1:1").osis()).toEqual("Num.1.1", "parsing: 'Vierte Mose 1:1'")
+		expect(p.parse("4. Mose 1:1").osis()).toEqual("Num.1.1", "parsing: '4. Mose 1:1'")
+		expect(p.parse("4 Mose 1:1").osis()).toEqual("Num.1.1", "parsing: '4 Mose 1:1'")
+		expect(p.parse("4. Mos 1:1").osis()).toEqual("Num.1.1", "parsing: '4. Mos 1:1'")
+		expect(p.parse("Numeri 1:1").osis()).toEqual("Num.1.1", "parsing: 'Numeri 1:1'")
+		expect(p.parse("4 Mos 1:1").osis()).toEqual("Num.1.1", "parsing: '4 Mos 1:1'")
+		expect(p.parse("4. Mo 1:1").osis()).toEqual("Num.1.1", "parsing: '4. Mo 1:1'")
+		expect(p.parse("4 Mo 1:1").osis()).toEqual("Num.1.1", "parsing: '4 Mo 1:1'")
+		expect(p.parse("Num 1:1").osis()).toEqual("Num.1.1", "parsing: 'Num 1:1'")
+		expect(p.parse("Nm 1:1").osis()).toEqual("Num.1.1", "parsing: 'Nm 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("VIERTE BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 BUCH MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("VIERTE MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 MOSE 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. MOS 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("NUMERI 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 MOS 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4. MO 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("4 MO 1:1").osis()).toEqual("Num.1.1")
-		expect(p.parse("NUM 1:1").osis()).toEqual("Num.1.1")
+		expect(p.parse("VIERTEN BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTEN BUCH MOSE 1:1'")
+		expect(p.parse("VIERTES BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTES BUCH MOSE 1:1'")
+		expect(p.parse("VIERTE BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTE BUCH MOSE 1:1'")
+		expect(p.parse("4. BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: '4. BUCH MOSE 1:1'")
+		expect(p.parse("VIERTEN MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTEN MOSE 1:1'")
+		expect(p.parse("VIERTES MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTES MOSE 1:1'")
+		expect(p.parse("4 BUCH MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: '4 BUCH MOSE 1:1'")
+		expect(p.parse("VIERTE MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: 'VIERTE MOSE 1:1'")
+		expect(p.parse("4. MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: '4. MOSE 1:1'")
+		expect(p.parse("4 MOSE 1:1").osis()).toEqual("Num.1.1", "parsing: '4 MOSE 1:1'")
+		expect(p.parse("4. MOS 1:1").osis()).toEqual("Num.1.1", "parsing: '4. MOS 1:1'")
+		expect(p.parse("NUMERI 1:1").osis()).toEqual("Num.1.1", "parsing: 'NUMERI 1:1'")
+		expect(p.parse("4 MOS 1:1").osis()).toEqual("Num.1.1", "parsing: '4 MOS 1:1'")
+		expect(p.parse("4. MO 1:1").osis()).toEqual("Num.1.1", "parsing: '4. MO 1:1'")
+		expect(p.parse("4 MO 1:1").osis()).toEqual("Num.1.1", "parsing: '4 MO 1:1'")
+		expect(p.parse("NUM 1:1").osis()).toEqual("Num.1.1", "parsing: 'NUM 1:1'")
+		expect(p.parse("NM 1:1").osis()).toEqual("Num.1.1", "parsing: 'NM 1:1'")
 		;
       return true;
     });
@@ -288,9 +340,9 @@
     });
     return it("should handle book: Sir (de)", function() {
       
-		expect(p.parse("Ecclesiasticus 1:1").osis()).toEqual("Sir.1.1")
-		expect(p.parse("Jesus Sirach 1:1").osis()).toEqual("Sir.1.1")
-		expect(p.parse("Sir 1:1").osis()).toEqual("Sir.1.1")
+		expect(p.parse("Ecclesiasticus 1:1").osis()).toEqual("Sir.1.1", "parsing: 'Ecclesiasticus 1:1'")
+		expect(p.parse("Jesus Sirach 1:1").osis()).toEqual("Sir.1.1", "parsing: 'Jesus Sirach 1:1'")
+		expect(p.parse("Sir 1:1").osis()).toEqual("Sir.1.1", "parsing: 'Sir 1:1'")
 		;
       return true;
     });
@@ -311,10 +363,10 @@
     });
     return it("should handle book: Wis (de)", function() {
       
-		expect(p.parse("Weisheit Salomos 1:1").osis()).toEqual("Wis.1.1")
-		expect(p.parse("Weisheit 1:1").osis()).toEqual("Wis.1.1")
-		expect(p.parse("Weish 1:1").osis()).toEqual("Wis.1.1")
-		expect(p.parse("Wis 1:1").osis()).toEqual("Wis.1.1")
+		expect(p.parse("Weisheit Salomos 1:1").osis()).toEqual("Wis.1.1", "parsing: 'Weisheit Salomos 1:1'")
+		expect(p.parse("Weisheit 1:1").osis()).toEqual("Wis.1.1", "parsing: 'Weisheit 1:1'")
+		expect(p.parse("Weish 1:1").osis()).toEqual("Wis.1.1", "parsing: 'Weish 1:1'")
+		expect(p.parse("Wis 1:1").osis()).toEqual("Wis.1.1", "parsing: 'Wis 1:1'")
 		;
       return true;
     });
@@ -335,17 +387,17 @@
     });
     return it("should handle book: Lam (de)", function() {
       
-		expect(p.parse("Klagelieder Jeremias 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("Klagelieder 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("Klag 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("Klgl 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("Lam 1:1").osis()).toEqual("Lam.1.1")
+		expect(p.parse("Klagelieder Jeremias 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Klagelieder Jeremias 1:1'")
+		expect(p.parse("Klagelieder 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Klagelieder 1:1'")
+		expect(p.parse("Klag 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Klag 1:1'")
+		expect(p.parse("Klgl 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Klgl 1:1'")
+		expect(p.parse("Lam 1:1").osis()).toEqual("Lam.1.1", "parsing: 'Lam 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("KLAGELIEDER JEREMIAS 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("KLAGELIEDER 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("KLAG 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("KLGL 1:1").osis()).toEqual("Lam.1.1")
-		expect(p.parse("LAM 1:1").osis()).toEqual("Lam.1.1")
+		expect(p.parse("KLAGELIEDER JEREMIAS 1:1").osis()).toEqual("Lam.1.1", "parsing: 'KLAGELIEDER JEREMIAS 1:1'")
+		expect(p.parse("KLAGELIEDER 1:1").osis()).toEqual("Lam.1.1", "parsing: 'KLAGELIEDER 1:1'")
+		expect(p.parse("KLAG 1:1").osis()).toEqual("Lam.1.1", "parsing: 'KLAG 1:1'")
+		expect(p.parse("KLGL 1:1").osis()).toEqual("Lam.1.1", "parsing: 'KLGL 1:1'")
+		expect(p.parse("LAM 1:1").osis()).toEqual("Lam.1.1", "parsing: 'LAM 1:1'")
 		;
       return true;
     });
@@ -366,9 +418,9 @@
     });
     return it("should handle book: EpJer (de)", function() {
       
-		expect(p.parse("Brief des Jeremia 1:1").osis()).toEqual("EpJer.1.1")
-		expect(p.parse("Br Jer 1:1").osis()).toEqual("EpJer.1.1")
-		expect(p.parse("EpJer 1:1").osis()).toEqual("EpJer.1.1")
+		expect(p.parse("Brief des Jeremia 1:1").osis()).toEqual("EpJer.1.1", "parsing: 'Brief des Jeremia 1:1'")
+		expect(p.parse("Br Jer 1:1").osis()).toEqual("EpJer.1.1", "parsing: 'Br Jer 1:1'")
+		expect(p.parse("EpJer 1:1").osis()).toEqual("EpJer.1.1", "parsing: 'EpJer 1:1'")
 		;
       return true;
     });
@@ -389,13 +441,13 @@
     });
     return it("should handle book: Rev (de)", function() {
       
-		expect(p.parse("Offenbarung 1:1").osis()).toEqual("Rev.1.1")
-		expect(p.parse("Offb 1:1").osis()).toEqual("Rev.1.1")
-		expect(p.parse("Rev 1:1").osis()).toEqual("Rev.1.1")
+		expect(p.parse("Offenbarung 1:1").osis()).toEqual("Rev.1.1", "parsing: 'Offenbarung 1:1'")
+		expect(p.parse("Offb 1:1").osis()).toEqual("Rev.1.1", "parsing: 'Offb 1:1'")
+		expect(p.parse("Rev 1:1").osis()).toEqual("Rev.1.1", "parsing: 'Rev 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("OFFENBARUNG 1:1").osis()).toEqual("Rev.1.1")
-		expect(p.parse("OFFB 1:1").osis()).toEqual("Rev.1.1")
-		expect(p.parse("REV 1:1").osis()).toEqual("Rev.1.1")
+		expect(p.parse("OFFENBARUNG 1:1").osis()).toEqual("Rev.1.1", "parsing: 'OFFENBARUNG 1:1'")
+		expect(p.parse("OFFB 1:1").osis()).toEqual("Rev.1.1", "parsing: 'OFFB 1:1'")
+		expect(p.parse("REV 1:1").osis()).toEqual("Rev.1.1", "parsing: 'REV 1:1'")
 		;
       return true;
     });
@@ -416,12 +468,14 @@
     });
     return it("should handle book: PrMan (de)", function() {
       
-		expect(p.parse("Gebet des Manasse 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("Gebet Manasses 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("Gebet Manasse 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("Geb Man 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("Or Man 1:1").osis()).toEqual("PrMan.1.1")
-		expect(p.parse("PrMan 1:1").osis()).toEqual("PrMan.1.1")
+		expect(p.parse("Das Gebet des Manasse 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Das Gebet des Manasse 1:1'")
+		expect(p.parse("Das Gebet Manasses 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Das Gebet Manasses 1:1'")
+		expect(p.parse("Gebet des Manasse 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Gebet des Manasse 1:1'")
+		expect(p.parse("Gebet Manasses 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Gebet Manasses 1:1'")
+		expect(p.parse("Gebet Manasse 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Gebet Manasse 1:1'")
+		expect(p.parse("Geb Man 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Geb Man 1:1'")
+		expect(p.parse("Or Man 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'Or Man 1:1'")
+		expect(p.parse("PrMan 1:1").osis()).toEqual("PrMan.1.1", "parsing: 'PrMan 1:1'")
 		;
       return true;
     });
@@ -442,37 +496,39 @@
     });
     return it("should handle book: Deut (de)", function() {
       
-		expect(p.parse("Funfte Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Fünfte Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Deuteronomium 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 Buch Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Funfte Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Fünfte Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 Mose 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. Mos 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 Mos 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. Mo 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 Mo 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Deut 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("Dtn 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("Funftes Buch Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Funftes Buch Mose 1:1'")
+		expect(p.parse("Fünftes Buch Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Fünftes Buch Mose 1:1'")
+		expect(p.parse("Deuteronomium 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Deuteronomium 1:1'")
+		expect(p.parse("5. Buch Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. Buch Mose 1:1'")
+		expect(p.parse("Funftes Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Funftes Mose 1:1'")
+		expect(p.parse("Fünftes Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Fünftes Mose 1:1'")
+		expect(p.parse("5 Buch Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 Buch Mose 1:1'")
+		expect(p.parse("5. Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. Mose 1:1'")
+		expect(p.parse("5 Mose 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 Mose 1:1'")
+		expect(p.parse("5. Mos 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. Mos 1:1'")
+		expect(p.parse("5 Mos 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 Mos 1:1'")
+		expect(p.parse("5. Mo 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. Mo 1:1'")
+		expect(p.parse("5 Mo 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 Mo 1:1'")
+		expect(p.parse("Deut 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Deut 1:1'")
+		expect(p.parse("Dtn 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Dtn 1:1'")
+		expect(p.parse("Dt 1:1").osis()).toEqual("Deut.1.1", "parsing: 'Dt 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("FUNFTE BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("FÜNFTE BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("DEUTERONOMIUM 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 BUCH MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("FUNFTE MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("FÜNFTE MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 MOSE 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. MOS 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 MOS 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5. MO 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("5 MO 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("DEUT 1:1").osis()).toEqual("Deut.1.1")
-		expect(p.parse("DTN 1:1").osis()).toEqual("Deut.1.1")
+		expect(p.parse("FUNFTES BUCH MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: 'FUNFTES BUCH MOSE 1:1'")
+		expect(p.parse("FÜNFTES BUCH MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: 'FÜNFTES BUCH MOSE 1:1'")
+		expect(p.parse("DEUTERONOMIUM 1:1").osis()).toEqual("Deut.1.1", "parsing: 'DEUTERONOMIUM 1:1'")
+		expect(p.parse("5. BUCH MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. BUCH MOSE 1:1'")
+		expect(p.parse("FUNFTES MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: 'FUNFTES MOSE 1:1'")
+		expect(p.parse("FÜNFTES MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: 'FÜNFTES MOSE 1:1'")
+		expect(p.parse("5 BUCH MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 BUCH MOSE 1:1'")
+		expect(p.parse("5. MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. MOSE 1:1'")
+		expect(p.parse("5 MOSE 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 MOSE 1:1'")
+		expect(p.parse("5. MOS 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. MOS 1:1'")
+		expect(p.parse("5 MOS 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 MOS 1:1'")
+		expect(p.parse("5. MO 1:1").osis()).toEqual("Deut.1.1", "parsing: '5. MO 1:1'")
+		expect(p.parse("5 MO 1:1").osis()).toEqual("Deut.1.1", "parsing: '5 MO 1:1'")
+		expect(p.parse("DEUT 1:1").osis()).toEqual("Deut.1.1", "parsing: 'DEUT 1:1'")
+		expect(p.parse("DTN 1:1").osis()).toEqual("Deut.1.1", "parsing: 'DTN 1:1'")
+		expect(p.parse("DT 1:1").osis()).toEqual("Deut.1.1", "parsing: 'DT 1:1'")
 		;
       return true;
     });
@@ -493,13 +549,13 @@
     });
     return it("should handle book: Josh (de)", function() {
       
-		expect(p.parse("Josua 1:1").osis()).toEqual("Josh.1.1")
-		expect(p.parse("Josh 1:1").osis()).toEqual("Josh.1.1")
-		expect(p.parse("Jos 1:1").osis()).toEqual("Josh.1.1")
+		expect(p.parse("Josua 1:1").osis()).toEqual("Josh.1.1", "parsing: 'Josua 1:1'")
+		expect(p.parse("Josh 1:1").osis()).toEqual("Josh.1.1", "parsing: 'Josh 1:1'")
+		expect(p.parse("Jos 1:1").osis()).toEqual("Josh.1.1", "parsing: 'Jos 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JOSUA 1:1").osis()).toEqual("Josh.1.1")
-		expect(p.parse("JOSH 1:1").osis()).toEqual("Josh.1.1")
-		expect(p.parse("JOS 1:1").osis()).toEqual("Josh.1.1")
+		expect(p.parse("JOSUA 1:1").osis()).toEqual("Josh.1.1", "parsing: 'JOSUA 1:1'")
+		expect(p.parse("JOSH 1:1").osis()).toEqual("Josh.1.1", "parsing: 'JOSH 1:1'")
+		expect(p.parse("JOS 1:1").osis()).toEqual("Josh.1.1", "parsing: 'JOS 1:1'")
 		;
       return true;
     });
@@ -520,13 +576,15 @@
     });
     return it("should handle book: Judg (de)", function() {
       
-		expect(p.parse("Richter 1:1").osis()).toEqual("Judg.1.1")
-		expect(p.parse("Judg 1:1").osis()).toEqual("Judg.1.1")
-		expect(p.parse("Ri 1:1").osis()).toEqual("Judg.1.1")
+		expect(p.parse("Richter 1:1").osis()).toEqual("Judg.1.1", "parsing: 'Richter 1:1'")
+		expect(p.parse("Judg 1:1").osis()).toEqual("Judg.1.1", "parsing: 'Judg 1:1'")
+		expect(p.parse("Rich 1:1").osis()).toEqual("Judg.1.1", "parsing: 'Rich 1:1'")
+		expect(p.parse("Ri 1:1").osis()).toEqual("Judg.1.1", "parsing: 'Ri 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("RICHTER 1:1").osis()).toEqual("Judg.1.1")
-		expect(p.parse("JUDG 1:1").osis()).toEqual("Judg.1.1")
-		expect(p.parse("RI 1:1").osis()).toEqual("Judg.1.1")
+		expect(p.parse("RICHTER 1:1").osis()).toEqual("Judg.1.1", "parsing: 'RICHTER 1:1'")
+		expect(p.parse("JUDG 1:1").osis()).toEqual("Judg.1.1", "parsing: 'JUDG 1:1'")
+		expect(p.parse("RICH 1:1").osis()).toEqual("Judg.1.1", "parsing: 'RICH 1:1'")
+		expect(p.parse("RI 1:1").osis()).toEqual("Judg.1.1", "parsing: 'RI 1:1'")
 		;
       return true;
     });
@@ -547,11 +605,13 @@
     });
     return it("should handle book: Ruth (de)", function() {
       
-		expect(p.parse("Ruth 1:1").osis()).toEqual("Ruth.1.1")
-		expect(p.parse("Rut 1:1").osis()).toEqual("Ruth.1.1")
+		expect(p.parse("Ruth 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'Ruth 1:1'")
+		expect(p.parse("Rut 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'Rut 1:1'")
+		expect(p.parse("Ru 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'Ru 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("RUTH 1:1").osis()).toEqual("Ruth.1.1")
-		expect(p.parse("RUT 1:1").osis()).toEqual("Ruth.1.1")
+		expect(p.parse("RUTH 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'RUTH 1:1'")
+		expect(p.parse("RUT 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'RUT 1:1'")
+		expect(p.parse("RU 1:1").osis()).toEqual("Ruth.1.1", "parsing: 'RU 1:1'")
 		;
       return true;
     });
@@ -572,14 +632,25 @@
     });
     return it("should handle book: 1Esd (de)", function() {
       
-		expect(p.parse("Erste Esra 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1. Esra 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1 Esra 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1. Esr 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1 Esr 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1. Es 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1 Es 1:1").osis()).toEqual("1Esd.1.1")
-		expect(p.parse("1Esd 1:1").osis()).toEqual("1Esd.1.1")
+		expect(p.parse("Ersten Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Ersten Esdra 1:1'")
+		expect(p.parse("Erster Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erster Esdra 1:1'")
+		expect(p.parse("Erstes Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erstes Esdra 1:1'")
+		expect(p.parse("Erste Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erste Esdra 1:1'")
+		expect(p.parse("Ersten Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Ersten Esra 1:1'")
+		expect(p.parse("Erster Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erster Esra 1:1'")
+		expect(p.parse("Erstes Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erstes Esra 1:1'")
+		expect(p.parse("Erste Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: 'Erste Esra 1:1'")
+		expect(p.parse("1. Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Esdra 1:1'")
+		expect(p.parse("1 Esdra 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Esdra 1:1'")
+		expect(p.parse("1. Esdr 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Esdr 1:1'")
+		expect(p.parse("1. Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Esra 1:1'")
+		expect(p.parse("1 Esdr 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Esdr 1:1'")
+		expect(p.parse("1 Esra 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Esra 1:1'")
+		expect(p.parse("1. Esr 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Esr 1:1'")
+		expect(p.parse("1 Esr 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Esr 1:1'")
+		expect(p.parse("1. Es 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1. Es 1:1'")
+		expect(p.parse("1 Es 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1 Es 1:1'")
+		expect(p.parse("1Esd 1:1").osis()).toEqual("1Esd.1.1", "parsing: '1Esd 1:1'")
 		;
       return true;
     });
@@ -600,14 +671,25 @@
     });
     return it("should handle book: 2Esd (de)", function() {
       
-		expect(p.parse("Zweite Esra 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2. Esra 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2 Esra 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2. Esr 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2 Esr 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2. Es 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2 Es 1:1").osis()).toEqual("2Esd.1.1")
-		expect(p.parse("2Esd 1:1").osis()).toEqual("2Esd.1.1")
+		expect(p.parse("Zweiten Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweiten Esdra 1:1'")
+		expect(p.parse("Zweiter Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweiter Esdra 1:1'")
+		expect(p.parse("Zweites Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweites Esdra 1:1'")
+		expect(p.parse("Zweite Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweite Esdra 1:1'")
+		expect(p.parse("Zweiten Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweiten Esra 1:1'")
+		expect(p.parse("Zweiter Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweiter Esra 1:1'")
+		expect(p.parse("Zweites Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweites Esra 1:1'")
+		expect(p.parse("Zweite Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: 'Zweite Esra 1:1'")
+		expect(p.parse("2. Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Esdra 1:1'")
+		expect(p.parse("2 Esdra 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Esdra 1:1'")
+		expect(p.parse("2. Esdr 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Esdr 1:1'")
+		expect(p.parse("2. Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Esra 1:1'")
+		expect(p.parse("2 Esdr 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Esdr 1:1'")
+		expect(p.parse("2 Esra 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Esra 1:1'")
+		expect(p.parse("2. Esr 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Esr 1:1'")
+		expect(p.parse("2 Esr 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Esr 1:1'")
+		expect(p.parse("2. Es 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2. Es 1:1'")
+		expect(p.parse("2 Es 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2 Es 1:1'")
+		expect(p.parse("2Esd 1:1").osis()).toEqual("2Esd.1.1", "parsing: '2Esd 1:1'")
 		;
       return true;
     });
@@ -628,15 +710,15 @@
     });
     return it("should handle book: Isa (de)", function() {
       
-		expect(p.parse("Isaias 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("Jesaja 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("Isa 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("Jes 1:1").osis()).toEqual("Isa.1.1")
+		expect(p.parse("Isaias 1:1").osis()).toEqual("Isa.1.1", "parsing: 'Isaias 1:1'")
+		expect(p.parse("Jesaja 1:1").osis()).toEqual("Isa.1.1", "parsing: 'Jesaja 1:1'")
+		expect(p.parse("Isa 1:1").osis()).toEqual("Isa.1.1", "parsing: 'Isa 1:1'")
+		expect(p.parse("Jes 1:1").osis()).toEqual("Isa.1.1", "parsing: 'Jes 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ISAIAS 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("JESAJA 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("ISA 1:1").osis()).toEqual("Isa.1.1")
-		expect(p.parse("JES 1:1").osis()).toEqual("Isa.1.1")
+		expect(p.parse("ISAIAS 1:1").osis()).toEqual("Isa.1.1", "parsing: 'ISAIAS 1:1'")
+		expect(p.parse("JESAJA 1:1").osis()).toEqual("Isa.1.1", "parsing: 'JESAJA 1:1'")
+		expect(p.parse("ISA 1:1").osis()).toEqual("Isa.1.1", "parsing: 'ISA 1:1'")
+		expect(p.parse("JES 1:1").osis()).toEqual("Isa.1.1", "parsing: 'JES 1:1'")
 		;
       return true;
     });
@@ -657,19 +739,29 @@
     });
     return it("should handle book: 2Sam (de)", function() {
       
-		expect(p.parse("Zweite Samuel 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2. Samuel 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2 Samuel 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2. Sam 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2 Sam 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2Sam 1:1").osis()).toEqual("2Sam.1.1")
+		expect(p.parse("Zweiten Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'Zweiten Samuel 1:1'")
+		expect(p.parse("Zweiter Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'Zweiter Samuel 1:1'")
+		expect(p.parse("Zweites Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'Zweites Samuel 1:1'")
+		expect(p.parse("Zweite Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'Zweite Samuel 1:1'")
+		expect(p.parse("2. Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. Samuel 1:1'")
+		expect(p.parse("2 Samuel 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 Samuel 1:1'")
+		expect(p.parse("2. Sam 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. Sam 1:1'")
+		expect(p.parse("2 Sam 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 Sam 1:1'")
+		expect(p.parse("2. Sa 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. Sa 1:1'")
+		expect(p.parse("2 Sa 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 Sa 1:1'")
+		expect(p.parse("2Sam 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2Sam 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITE SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2. SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2 SAMUEL 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2. SAM 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2 SAM 1:1").osis()).toEqual("2Sam.1.1")
-		expect(p.parse("2SAM 1:1").osis()).toEqual("2Sam.1.1")
+		expect(p.parse("ZWEITEN SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'ZWEITEN SAMUEL 1:1'")
+		expect(p.parse("ZWEITER SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'ZWEITER SAMUEL 1:1'")
+		expect(p.parse("ZWEITES SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'ZWEITES SAMUEL 1:1'")
+		expect(p.parse("ZWEITE SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: 'ZWEITE SAMUEL 1:1'")
+		expect(p.parse("2. SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. SAMUEL 1:1'")
+		expect(p.parse("2 SAMUEL 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 SAMUEL 1:1'")
+		expect(p.parse("2. SAM 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. SAM 1:1'")
+		expect(p.parse("2 SAM 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 SAM 1:1'")
+		expect(p.parse("2. SA 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2. SA 1:1'")
+		expect(p.parse("2 SA 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2 SA 1:1'")
+		expect(p.parse("2SAM 1:1").osis()).toEqual("2Sam.1.1", "parsing: '2SAM 1:1'")
 		;
       return true;
     });
@@ -690,19 +782,29 @@
     });
     return it("should handle book: 1Sam (de)", function() {
       
-		expect(p.parse("Erste Samuel 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1. Samuel 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1 Samuel 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1. Sam 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1 Sam 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1Sam 1:1").osis()).toEqual("1Sam.1.1")
+		expect(p.parse("Ersten Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'Ersten Samuel 1:1'")
+		expect(p.parse("Erster Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'Erster Samuel 1:1'")
+		expect(p.parse("Erstes Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'Erstes Samuel 1:1'")
+		expect(p.parse("Erste Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'Erste Samuel 1:1'")
+		expect(p.parse("1. Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. Samuel 1:1'")
+		expect(p.parse("1 Samuel 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 Samuel 1:1'")
+		expect(p.parse("1. Sam 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. Sam 1:1'")
+		expect(p.parse("1 Sam 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 Sam 1:1'")
+		expect(p.parse("1. Sa 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. Sa 1:1'")
+		expect(p.parse("1 Sa 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 Sa 1:1'")
+		expect(p.parse("1Sam 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1Sam 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTE SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1. SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1 SAMUEL 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1. SAM 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1 SAM 1:1").osis()).toEqual("1Sam.1.1")
-		expect(p.parse("1SAM 1:1").osis()).toEqual("1Sam.1.1")
+		expect(p.parse("ERSTEN SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'ERSTEN SAMUEL 1:1'")
+		expect(p.parse("ERSTER SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'ERSTER SAMUEL 1:1'")
+		expect(p.parse("ERSTES SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'ERSTES SAMUEL 1:1'")
+		expect(p.parse("ERSTE SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: 'ERSTE SAMUEL 1:1'")
+		expect(p.parse("1. SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. SAMUEL 1:1'")
+		expect(p.parse("1 SAMUEL 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 SAMUEL 1:1'")
+		expect(p.parse("1. SAM 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. SAM 1:1'")
+		expect(p.parse("1 SAM 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 SAM 1:1'")
+		expect(p.parse("1. SA 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1. SA 1:1'")
+		expect(p.parse("1 SA 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1 SA 1:1'")
+		expect(p.parse("1SAM 1:1").osis()).toEqual("1Sam.1.1", "parsing: '1SAM 1:1'")
 		;
       return true;
     });
@@ -723,35 +825,73 @@
     });
     return it("should handle book: 2Kgs (de)", function() {
       
-		expect(p.parse("Zweite Koenige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("Zweite Konige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("Zweite Könige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Koenige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Koenige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Konige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Könige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Konige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Könige 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Kon 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. Kön 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Kon 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 Kön 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2Kgs 1:1").osis()).toEqual("2Kgs.1.1")
+		expect(p.parse("Zweiten Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiten Koenige 1:1'")
+		expect(p.parse("Zweiter Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiter Koenige 1:1'")
+		expect(p.parse("Zweites Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweites Koenige 1:1'")
+		expect(p.parse("Zweite Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweite Koenige 1:1'")
+		expect(p.parse("Zweiten Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiten Konige 1:1'")
+		expect(p.parse("Zweiten Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiten Könige 1:1'")
+		expect(p.parse("Zweiter Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiter Konige 1:1'")
+		expect(p.parse("Zweiter Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweiter Könige 1:1'")
+		expect(p.parse("Zweites Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweites Konige 1:1'")
+		expect(p.parse("Zweites Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweites Könige 1:1'")
+		expect(p.parse("Zweite Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweite Konige 1:1'")
+		expect(p.parse("Zweite Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'Zweite Könige 1:1'")
+		expect(p.parse("2. Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Koenige 1:1'")
+		expect(p.parse("2 Koenige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Koenige 1:1'")
+		expect(p.parse("2. Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Konige 1:1'")
+		expect(p.parse("2. Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Könige 1:1'")
+		expect(p.parse("2 Konige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Konige 1:1'")
+		expect(p.parse("2 Könige 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Könige 1:1'")
+		expect(p.parse("2. Koen 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Koen 1:1'")
+		expect(p.parse("2 Koen 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Koen 1:1'")
+		expect(p.parse("2. Kng 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Kng 1:1'")
+		expect(p.parse("2. Koe 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Koe 1:1'")
+		expect(p.parse("2. Kon 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Kon 1:1'")
+		expect(p.parse("2. Kön 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Kön 1:1'")
+		expect(p.parse("2 Kng 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Kng 1:1'")
+		expect(p.parse("2 Koe 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Koe 1:1'")
+		expect(p.parse("2 Kon 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Kon 1:1'")
+		expect(p.parse("2 Kön 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Kön 1:1'")
+		expect(p.parse("2. Ko 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Ko 1:1'")
+		expect(p.parse("2. Kö 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. Kö 1:1'")
+		expect(p.parse("2 Ko 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Ko 1:1'")
+		expect(p.parse("2 Kö 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 Kö 1:1'")
+		expect(p.parse("2Kgs 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2Kgs 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITE KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("ZWEITE KONIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("ZWEITE KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KOENIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KONIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KONIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KON 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2. KÖN 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KON 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2 KÖN 1:1").osis()).toEqual("2Kgs.1.1")
-		expect(p.parse("2KGS 1:1").osis()).toEqual("2Kgs.1.1")
+		expect(p.parse("ZWEITEN KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITEN KOENIGE 1:1'")
+		expect(p.parse("ZWEITER KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITER KOENIGE 1:1'")
+		expect(p.parse("ZWEITES KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITES KOENIGE 1:1'")
+		expect(p.parse("ZWEITE KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITE KOENIGE 1:1'")
+		expect(p.parse("ZWEITEN KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITEN KONIGE 1:1'")
+		expect(p.parse("ZWEITEN KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITEN KÖNIGE 1:1'")
+		expect(p.parse("ZWEITER KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITER KONIGE 1:1'")
+		expect(p.parse("ZWEITER KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITER KÖNIGE 1:1'")
+		expect(p.parse("ZWEITES KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITES KONIGE 1:1'")
+		expect(p.parse("ZWEITES KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITES KÖNIGE 1:1'")
+		expect(p.parse("ZWEITE KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITE KONIGE 1:1'")
+		expect(p.parse("ZWEITE KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: 'ZWEITE KÖNIGE 1:1'")
+		expect(p.parse("2. KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KOENIGE 1:1'")
+		expect(p.parse("2 KOENIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KOENIGE 1:1'")
+		expect(p.parse("2. KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KONIGE 1:1'")
+		expect(p.parse("2. KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KÖNIGE 1:1'")
+		expect(p.parse("2 KONIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KONIGE 1:1'")
+		expect(p.parse("2 KÖNIGE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KÖNIGE 1:1'")
+		expect(p.parse("2. KOEN 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KOEN 1:1'")
+		expect(p.parse("2 KOEN 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KOEN 1:1'")
+		expect(p.parse("2. KNG 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KNG 1:1'")
+		expect(p.parse("2. KOE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KOE 1:1'")
+		expect(p.parse("2. KON 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KON 1:1'")
+		expect(p.parse("2. KÖN 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KÖN 1:1'")
+		expect(p.parse("2 KNG 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KNG 1:1'")
+		expect(p.parse("2 KOE 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KOE 1:1'")
+		expect(p.parse("2 KON 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KON 1:1'")
+		expect(p.parse("2 KÖN 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KÖN 1:1'")
+		expect(p.parse("2. KO 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KO 1:1'")
+		expect(p.parse("2. KÖ 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2. KÖ 1:1'")
+		expect(p.parse("2 KO 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KO 1:1'")
+		expect(p.parse("2 KÖ 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2 KÖ 1:1'")
+		expect(p.parse("2KGS 1:1").osis()).toEqual("2Kgs.1.1", "parsing: '2KGS 1:1'")
 		;
       return true;
     });
@@ -772,35 +912,73 @@
     });
     return it("should handle book: 1Kgs (de)", function() {
       
-		expect(p.parse("Erste Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("Erste Konige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("Erste Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Koenige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Konige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Konige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Könige 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Kon 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. Kön 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Kon 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 Kön 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1Kgs 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("Ersten Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Ersten Koenige 1:1'")
+		expect(p.parse("Erster Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erster Koenige 1:1'")
+		expect(p.parse("Erstes Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erstes Koenige 1:1'")
+		expect(p.parse("Erste Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erste Koenige 1:1'")
+		expect(p.parse("Ersten Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Ersten Konige 1:1'")
+		expect(p.parse("Ersten Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Ersten Könige 1:1'")
+		expect(p.parse("Erster Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erster Konige 1:1'")
+		expect(p.parse("Erster Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erster Könige 1:1'")
+		expect(p.parse("Erstes Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erstes Konige 1:1'")
+		expect(p.parse("Erstes Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erstes Könige 1:1'")
+		expect(p.parse("Erste Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erste Konige 1:1'")
+		expect(p.parse("Erste Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'Erste Könige 1:1'")
+		expect(p.parse("1. Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Koenige 1:1'")
+		expect(p.parse("1 Koenige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Koenige 1:1'")
+		expect(p.parse("1. Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Konige 1:1'")
+		expect(p.parse("1. Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Könige 1:1'")
+		expect(p.parse("1 Konige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Konige 1:1'")
+		expect(p.parse("1 Könige 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Könige 1:1'")
+		expect(p.parse("1. Koen 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Koen 1:1'")
+		expect(p.parse("1 Koen 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Koen 1:1'")
+		expect(p.parse("1. Kng 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Kng 1:1'")
+		expect(p.parse("1. Koe 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Koe 1:1'")
+		expect(p.parse("1. Kon 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Kon 1:1'")
+		expect(p.parse("1. Kön 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Kön 1:1'")
+		expect(p.parse("1 Kng 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Kng 1:1'")
+		expect(p.parse("1 Koe 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Koe 1:1'")
+		expect(p.parse("1 Kon 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Kon 1:1'")
+		expect(p.parse("1 Kön 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Kön 1:1'")
+		expect(p.parse("1. Ko 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Ko 1:1'")
+		expect(p.parse("1. Kö 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. Kö 1:1'")
+		expect(p.parse("1 Ko 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Ko 1:1'")
+		expect(p.parse("1 Kö 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 Kö 1:1'")
+		expect(p.parse("1Kgs 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1Kgs 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTE KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("ERSTE KONIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("ERSTE KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KOENIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KONIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KONIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KON 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1. KÖN 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KON 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1 KÖN 1:1").osis()).toEqual("1Kgs.1.1")
-		expect(p.parse("1KGS 1:1").osis()).toEqual("1Kgs.1.1")
+		expect(p.parse("ERSTEN KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTEN KOENIGE 1:1'")
+		expect(p.parse("ERSTER KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTER KOENIGE 1:1'")
+		expect(p.parse("ERSTES KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTES KOENIGE 1:1'")
+		expect(p.parse("ERSTE KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTE KOENIGE 1:1'")
+		expect(p.parse("ERSTEN KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTEN KONIGE 1:1'")
+		expect(p.parse("ERSTEN KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTEN KÖNIGE 1:1'")
+		expect(p.parse("ERSTER KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTER KONIGE 1:1'")
+		expect(p.parse("ERSTER KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTER KÖNIGE 1:1'")
+		expect(p.parse("ERSTES KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTES KONIGE 1:1'")
+		expect(p.parse("ERSTES KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTES KÖNIGE 1:1'")
+		expect(p.parse("ERSTE KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTE KONIGE 1:1'")
+		expect(p.parse("ERSTE KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: 'ERSTE KÖNIGE 1:1'")
+		expect(p.parse("1. KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KOENIGE 1:1'")
+		expect(p.parse("1 KOENIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KOENIGE 1:1'")
+		expect(p.parse("1. KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KONIGE 1:1'")
+		expect(p.parse("1. KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KÖNIGE 1:1'")
+		expect(p.parse("1 KONIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KONIGE 1:1'")
+		expect(p.parse("1 KÖNIGE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KÖNIGE 1:1'")
+		expect(p.parse("1. KOEN 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KOEN 1:1'")
+		expect(p.parse("1 KOEN 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KOEN 1:1'")
+		expect(p.parse("1. KNG 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KNG 1:1'")
+		expect(p.parse("1. KOE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KOE 1:1'")
+		expect(p.parse("1. KON 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KON 1:1'")
+		expect(p.parse("1. KÖN 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KÖN 1:1'")
+		expect(p.parse("1 KNG 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KNG 1:1'")
+		expect(p.parse("1 KOE 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KOE 1:1'")
+		expect(p.parse("1 KON 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KON 1:1'")
+		expect(p.parse("1 KÖN 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KÖN 1:1'")
+		expect(p.parse("1. KO 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KO 1:1'")
+		expect(p.parse("1. KÖ 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1. KÖ 1:1'")
+		expect(p.parse("1 KO 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KO 1:1'")
+		expect(p.parse("1 KÖ 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1 KÖ 1:1'")
+		expect(p.parse("1KGS 1:1").osis()).toEqual("1Kgs.1.1", "parsing: '1KGS 1:1'")
 		;
       return true;
     });
@@ -821,19 +999,29 @@
     });
     return it("should handle book: 2Chr (de)", function() {
       
-		expect(p.parse("Zweite Chronik 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2. Chronik 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2 Chronik 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2. Chr 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2 Chr 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2Chr 1:1").osis()).toEqual("2Chr.1.1")
+		expect(p.parse("Zweiten Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'Zweiten Chronik 1:1'")
+		expect(p.parse("Zweiter Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'Zweiter Chronik 1:1'")
+		expect(p.parse("Zweites Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'Zweites Chronik 1:1'")
+		expect(p.parse("Zweite Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'Zweite Chronik 1:1'")
+		expect(p.parse("2. Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. Chronik 1:1'")
+		expect(p.parse("2 Chronik 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 Chronik 1:1'")
+		expect(p.parse("2. Chron 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. Chron 1:1'")
+		expect(p.parse("2 Chron 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 Chron 1:1'")
+		expect(p.parse("2. Chr 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. Chr 1:1'")
+		expect(p.parse("2 Chr 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 Chr 1:1'")
+		expect(p.parse("2Chr 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2Chr 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITE CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2. CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2 CHRONIK 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2. CHR 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2 CHR 1:1").osis()).toEqual("2Chr.1.1")
-		expect(p.parse("2CHR 1:1").osis()).toEqual("2Chr.1.1")
+		expect(p.parse("ZWEITEN CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'ZWEITEN CHRONIK 1:1'")
+		expect(p.parse("ZWEITER CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'ZWEITER CHRONIK 1:1'")
+		expect(p.parse("ZWEITES CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'ZWEITES CHRONIK 1:1'")
+		expect(p.parse("ZWEITE CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: 'ZWEITE CHRONIK 1:1'")
+		expect(p.parse("2. CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. CHRONIK 1:1'")
+		expect(p.parse("2 CHRONIK 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 CHRONIK 1:1'")
+		expect(p.parse("2. CHRON 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. CHRON 1:1'")
+		expect(p.parse("2 CHRON 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 CHRON 1:1'")
+		expect(p.parse("2. CHR 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2. CHR 1:1'")
+		expect(p.parse("2 CHR 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2 CHR 1:1'")
+		expect(p.parse("2CHR 1:1").osis()).toEqual("2Chr.1.1", "parsing: '2CHR 1:1'")
 		;
       return true;
     });
@@ -854,19 +1042,29 @@
     });
     return it("should handle book: 1Chr (de)", function() {
       
-		expect(p.parse("Erste Chronik 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1. Chronik 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1 Chronik 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1. Chr 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1 Chr 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1Chr 1:1").osis()).toEqual("1Chr.1.1")
+		expect(p.parse("Ersten Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'Ersten Chronik 1:1'")
+		expect(p.parse("Erster Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'Erster Chronik 1:1'")
+		expect(p.parse("Erstes Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'Erstes Chronik 1:1'")
+		expect(p.parse("Erste Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'Erste Chronik 1:1'")
+		expect(p.parse("1. Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. Chronik 1:1'")
+		expect(p.parse("1 Chronik 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 Chronik 1:1'")
+		expect(p.parse("1. Chron 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. Chron 1:1'")
+		expect(p.parse("1 Chron 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 Chron 1:1'")
+		expect(p.parse("1. Chr 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. Chr 1:1'")
+		expect(p.parse("1 Chr 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 Chr 1:1'")
+		expect(p.parse("1Chr 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1Chr 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTE CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1. CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1 CHRONIK 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1. CHR 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1 CHR 1:1").osis()).toEqual("1Chr.1.1")
-		expect(p.parse("1CHR 1:1").osis()).toEqual("1Chr.1.1")
+		expect(p.parse("ERSTEN CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'ERSTEN CHRONIK 1:1'")
+		expect(p.parse("ERSTER CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'ERSTER CHRONIK 1:1'")
+		expect(p.parse("ERSTES CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'ERSTES CHRONIK 1:1'")
+		expect(p.parse("ERSTE CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: 'ERSTE CHRONIK 1:1'")
+		expect(p.parse("1. CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. CHRONIK 1:1'")
+		expect(p.parse("1 CHRONIK 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 CHRONIK 1:1'")
+		expect(p.parse("1. CHRON 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. CHRON 1:1'")
+		expect(p.parse("1 CHRON 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 CHRON 1:1'")
+		expect(p.parse("1. CHR 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1. CHR 1:1'")
+		expect(p.parse("1 CHR 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1 CHR 1:1'")
+		expect(p.parse("1CHR 1:1").osis()).toEqual("1Chr.1.1", "parsing: '1CHR 1:1'")
 		;
       return true;
     });
@@ -887,13 +1085,13 @@
     });
     return it("should handle book: Ezra (de)", function() {
       
-		expect(p.parse("Esra 1:1").osis()).toEqual("Ezra.1.1")
-		expect(p.parse("Ezra 1:1").osis()).toEqual("Ezra.1.1")
-		expect(p.parse("Esr 1:1").osis()).toEqual("Ezra.1.1")
+		expect(p.parse("Esra 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'Esra 1:1'")
+		expect(p.parse("Ezra 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'Ezra 1:1'")
+		expect(p.parse("Esr 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'Esr 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ESRA 1:1").osis()).toEqual("Ezra.1.1")
-		expect(p.parse("EZRA 1:1").osis()).toEqual("Ezra.1.1")
-		expect(p.parse("ESR 1:1").osis()).toEqual("Ezra.1.1")
+		expect(p.parse("ESRA 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'ESRA 1:1'")
+		expect(p.parse("EZRA 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'EZRA 1:1'")
+		expect(p.parse("ESR 1:1").osis()).toEqual("Ezra.1.1", "parsing: 'ESR 1:1'")
 		;
       return true;
     });
@@ -914,11 +1112,11 @@
     });
     return it("should handle book: Neh (de)", function() {
       
-		expect(p.parse("Nehemia 1:1").osis()).toEqual("Neh.1.1")
-		expect(p.parse("Neh 1:1").osis()).toEqual("Neh.1.1")
+		expect(p.parse("Nehemia 1:1").osis()).toEqual("Neh.1.1", "parsing: 'Nehemia 1:1'")
+		expect(p.parse("Neh 1:1").osis()).toEqual("Neh.1.1", "parsing: 'Neh 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("NEHEMIA 1:1").osis()).toEqual("Neh.1.1")
-		expect(p.parse("NEH 1:1").osis()).toEqual("Neh.1.1")
+		expect(p.parse("NEHEMIA 1:1").osis()).toEqual("Neh.1.1", "parsing: 'NEHEMIA 1:1'")
+		expect(p.parse("NEH 1:1").osis()).toEqual("Neh.1.1", "parsing: 'NEH 1:1'")
 		;
       return true;
     });
@@ -939,10 +1137,10 @@
     });
     return it("should handle book: GkEsth (de)", function() {
       
-		expect(p.parse("Ester \(Griechisch\) 1:1").osis()).toEqual("GkEsth.1.1")
-		expect(p.parse("Ester (Griechisch) 1:1").osis()).toEqual("GkEsth.1.1")
-		expect(p.parse("GkEsth 1:1").osis()).toEqual("GkEsth.1.1")
-		expect(p.parse("Gr Est 1:1").osis()).toEqual("GkEsth.1.1")
+		expect(p.parse("Ester \(Griechisch\) 1:1").osis()).toEqual("GkEsth.1.1", "parsing: 'Ester \(Griechisch\) 1:1'")
+		expect(p.parse("Ester (Griechisch) 1:1").osis()).toEqual("GkEsth.1.1", "parsing: 'Ester (Griechisch) 1:1'")
+		expect(p.parse("GkEsth 1:1").osis()).toEqual("GkEsth.1.1", "parsing: 'GkEsth 1:1'")
+		expect(p.parse("Gr Est 1:1").osis()).toEqual("GkEsth.1.1", "parsing: 'Gr Est 1:1'")
 		;
       return true;
     });
@@ -963,15 +1161,15 @@
     });
     return it("should handle book: Esth (de)", function() {
       
-		expect(p.parse("Esther 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("Ester 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("Esth 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("Est 1:1").osis()).toEqual("Esth.1.1")
+		expect(p.parse("Esther 1:1").osis()).toEqual("Esth.1.1", "parsing: 'Esther 1:1'")
+		expect(p.parse("Ester 1:1").osis()).toEqual("Esth.1.1", "parsing: 'Ester 1:1'")
+		expect(p.parse("Esth 1:1").osis()).toEqual("Esth.1.1", "parsing: 'Esth 1:1'")
+		expect(p.parse("Est 1:1").osis()).toEqual("Esth.1.1", "parsing: 'Est 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ESTHER 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("ESTER 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("ESTH 1:1").osis()).toEqual("Esth.1.1")
-		expect(p.parse("EST 1:1").osis()).toEqual("Esth.1.1")
+		expect(p.parse("ESTHER 1:1").osis()).toEqual("Esth.1.1", "parsing: 'ESTHER 1:1'")
+		expect(p.parse("ESTER 1:1").osis()).toEqual("Esth.1.1", "parsing: 'ESTER 1:1'")
+		expect(p.parse("ESTH 1:1").osis()).toEqual("Esth.1.1", "parsing: 'ESTH 1:1'")
+		expect(p.parse("EST 1:1").osis()).toEqual("Esth.1.1", "parsing: 'EST 1:1'")
 		;
       return true;
     });
@@ -992,15 +1190,15 @@
     });
     return it("should handle book: Job (de)", function() {
       
-		expect(p.parse("Hiob 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("Ijob 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("Job 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("Hi 1:1").osis()).toEqual("Job.1.1")
+		expect(p.parse("Hiob 1:1").osis()).toEqual("Job.1.1", "parsing: 'Hiob 1:1'")
+		expect(p.parse("Ijob 1:1").osis()).toEqual("Job.1.1", "parsing: 'Ijob 1:1'")
+		expect(p.parse("Job 1:1").osis()).toEqual("Job.1.1", "parsing: 'Job 1:1'")
+		expect(p.parse("Hi 1:1").osis()).toEqual("Job.1.1", "parsing: 'Hi 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HIOB 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("IJOB 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("JOB 1:1").osis()).toEqual("Job.1.1")
-		expect(p.parse("HI 1:1").osis()).toEqual("Job.1.1")
+		expect(p.parse("HIOB 1:1").osis()).toEqual("Job.1.1", "parsing: 'HIOB 1:1'")
+		expect(p.parse("IJOB 1:1").osis()).toEqual("Job.1.1", "parsing: 'IJOB 1:1'")
+		expect(p.parse("JOB 1:1").osis()).toEqual("Job.1.1", "parsing: 'JOB 1:1'")
+		expect(p.parse("HI 1:1").osis()).toEqual("Job.1.1", "parsing: 'HI 1:1'")
 		;
       return true;
     });
@@ -1021,13 +1219,15 @@
     });
     return it("should handle book: Ps (de)", function() {
       
-		expect(p.parse("Psalmen 1:1").osis()).toEqual("Ps.1.1")
-		expect(p.parse("Psalm 1:1").osis()).toEqual("Ps.1.1")
-		expect(p.parse("Ps 1:1").osis()).toEqual("Ps.1.1")
+		expect(p.parse("Psalmen 1:1").osis()).toEqual("Ps.1.1", "parsing: 'Psalmen 1:1'")
+		expect(p.parse("Psalm 1:1").osis()).toEqual("Ps.1.1", "parsing: 'Psalm 1:1'")
+		expect(p.parse("Pslm 1:1").osis()).toEqual("Ps.1.1", "parsing: 'Pslm 1:1'")
+		expect(p.parse("Ps 1:1").osis()).toEqual("Ps.1.1", "parsing: 'Ps 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("PSALMEN 1:1").osis()).toEqual("Ps.1.1")
-		expect(p.parse("PSALM 1:1").osis()).toEqual("Ps.1.1")
-		expect(p.parse("PS 1:1").osis()).toEqual("Ps.1.1")
+		expect(p.parse("PSALMEN 1:1").osis()).toEqual("Ps.1.1", "parsing: 'PSALMEN 1:1'")
+		expect(p.parse("PSALM 1:1").osis()).toEqual("Ps.1.1", "parsing: 'PSALM 1:1'")
+		expect(p.parse("PSLM 1:1").osis()).toEqual("Ps.1.1", "parsing: 'PSLM 1:1'")
+		expect(p.parse("PS 1:1").osis()).toEqual("Ps.1.1", "parsing: 'PS 1:1'")
 		;
       return true;
     });
@@ -1048,9 +1248,12 @@
     });
     return it("should handle book: PrAzar (de)", function() {
       
-		expect(p.parse("Gebet des Asarja 1:1").osis()).toEqual("PrAzar.1.1")
-		expect(p.parse("Geb As 1:1").osis()).toEqual("PrAzar.1.1")
-		expect(p.parse("PrAzar 1:1").osis()).toEqual("PrAzar.1.1")
+		expect(p.parse("Das Gebet des Asarja 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Das Gebet des Asarja 1:1'")
+		expect(p.parse("Das Gebet Asarjas 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Das Gebet Asarjas 1:1'")
+		expect(p.parse("Gebet des Asarja 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Gebet des Asarja 1:1'")
+		expect(p.parse("Gebet Asarjas 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Gebet Asarjas 1:1'")
+		expect(p.parse("Geb As 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'Geb As 1:1'")
+		expect(p.parse("PrAzar 1:1").osis()).toEqual("PrAzar.1.1", "parsing: 'PrAzar 1:1'")
 		;
       return true;
     });
@@ -1071,21 +1274,23 @@
     });
     return it("should handle book: Prov (de)", function() {
       
-		expect(p.parse("Sprichworter 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Sprichwörter 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Sprueche 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Spruche 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Sprüche 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Prov 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("Spr 1:1").osis()).toEqual("Prov.1.1")
+		expect(p.parse("Sprichwoerter 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprichwoerter 1:1'")
+		expect(p.parse("Sprichworter 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprichworter 1:1'")
+		expect(p.parse("Sprichwörter 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprichwörter 1:1'")
+		expect(p.parse("Sprueche 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprueche 1:1'")
+		expect(p.parse("Spruche 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Spruche 1:1'")
+		expect(p.parse("Sprüche 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Sprüche 1:1'")
+		expect(p.parse("Prov 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Prov 1:1'")
+		expect(p.parse("Spr 1:1").osis()).toEqual("Prov.1.1", "parsing: 'Spr 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("SPRICHWORTER 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPRICHWÖRTER 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPRUECHE 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPRUCHE 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPRÜCHE 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("PROV 1:1").osis()).toEqual("Prov.1.1")
-		expect(p.parse("SPR 1:1").osis()).toEqual("Prov.1.1")
+		expect(p.parse("SPRICHWOERTER 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRICHWOERTER 1:1'")
+		expect(p.parse("SPRICHWORTER 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRICHWORTER 1:1'")
+		expect(p.parse("SPRICHWÖRTER 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRICHWÖRTER 1:1'")
+		expect(p.parse("SPRUECHE 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRUECHE 1:1'")
+		expect(p.parse("SPRUCHE 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRUCHE 1:1'")
+		expect(p.parse("SPRÜCHE 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPRÜCHE 1:1'")
+		expect(p.parse("PROV 1:1").osis()).toEqual("Prov.1.1", "parsing: 'PROV 1:1'")
+		expect(p.parse("SPR 1:1").osis()).toEqual("Prov.1.1", "parsing: 'SPR 1:1'")
 		;
       return true;
     });
@@ -1106,21 +1311,21 @@
     });
     return it("should handle book: Eccl (de)", function() {
       
-		expect(p.parse("Ecclesiastes 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Ekklesiastes 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Prediger 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Kohelet 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Eccl 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Pred 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("Koh 1:1").osis()).toEqual("Eccl.1.1")
+		expect(p.parse("Ecclesiastes 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Ecclesiastes 1:1'")
+		expect(p.parse("Ekklesiastes 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Ekklesiastes 1:1'")
+		expect(p.parse("Prediger 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Prediger 1:1'")
+		expect(p.parse("Kohelet 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Kohelet 1:1'")
+		expect(p.parse("Eccl 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Eccl 1:1'")
+		expect(p.parse("Pred 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Pred 1:1'")
+		expect(p.parse("Koh 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'Koh 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ECCLESIASTES 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("EKKLESIASTES 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("PREDIGER 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("KOHELET 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("ECCL 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("PRED 1:1").osis()).toEqual("Eccl.1.1")
-		expect(p.parse("KOH 1:1").osis()).toEqual("Eccl.1.1")
+		expect(p.parse("ECCLESIASTES 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'ECCLESIASTES 1:1'")
+		expect(p.parse("EKKLESIASTES 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'EKKLESIASTES 1:1'")
+		expect(p.parse("PREDIGER 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'PREDIGER 1:1'")
+		expect(p.parse("KOHELET 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'KOHELET 1:1'")
+		expect(p.parse("ECCL 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'ECCL 1:1'")
+		expect(p.parse("PRED 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'PRED 1:1'")
+		expect(p.parse("KOH 1:1").osis()).toEqual("Eccl.1.1", "parsing: 'KOH 1:1'")
 		;
       return true;
     });
@@ -1141,18 +1346,17 @@
     });
     return it("should handle book: SgThree (de)", function() {
       
-		expect(p.parse("Lobgesang der drei jungen Manner im Feuerofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der drei jungen Männer im Feuerofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Der Gesang der Drei Manner im feurigen Ofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Der Gesang der Drei Männer im feurigen Ofen 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der drei jungen Manner 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der drei jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der 3 jungen Manner 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Lobgesang der 3 jungen Männer 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Der Gesang der Drei 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("Gesang der Drei 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("SgThree 1:1").osis()).toEqual("SgThree.1.1")
-		expect(p.parse("L3J 1:1").osis()).toEqual("SgThree.1.1")
+		expect(p.parse("Gesang der drei Maenner im Feuerofen 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Maenner im Feuerofen 1:1'")
+		expect(p.parse("Gesang der drei Manner im Feuerofen 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Manner im Feuerofen 1:1'")
+		expect(p.parse("Gesang der drei Männer im Feuerofen 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Männer im Feuerofen 1:1'")
+		expect(p.parse("Gesang der drei im Feuerofen 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei im Feuerofen 1:1'")
+		expect(p.parse("Gesang der drei Maenner 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Maenner 1:1'")
+		expect(p.parse("Gesang der drei Manner 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Manner 1:1'")
+		expect(p.parse("Gesang der drei Männer 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei Männer 1:1'")
+		expect(p.parse("Gesang der Drei 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der Drei 1:1'")
+		expect(p.parse("Gesang der drei 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'Gesang der drei 1:1'")
+		expect(p.parse("SgThree 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'SgThree 1:1'")
+		expect(p.parse("L3J 1:1").osis()).toEqual("SgThree.1.1", "parsing: 'L3J 1:1'")
 		;
       return true;
     });
@@ -1173,21 +1377,25 @@
     });
     return it("should handle book: Song (de)", function() {
       
-		expect(p.parse("Hohelied Salomonis 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hoheslied Salomos 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hohes Lied 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hoheslied 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hohelied 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Song 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("Hld 1:1").osis()).toEqual("Song.1.1")
+		expect(p.parse("Hoheslied Salomonis 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hoheslied Salomonis 1:1'")
+		expect(p.parse("Hohelied Salomonis 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hohelied Salomonis 1:1'")
+		expect(p.parse("Hoheslied Salomos 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hoheslied Salomos 1:1'")
+		expect(p.parse("Hohelied Salomos 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hohelied Salomos 1:1'")
+		expect(p.parse("Hohes Lied 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hohes Lied 1:1'")
+		expect(p.parse("Hoheslied 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hoheslied 1:1'")
+		expect(p.parse("Hohelied 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hohelied 1:1'")
+		expect(p.parse("Song 1:1").osis()).toEqual("Song.1.1", "parsing: 'Song 1:1'")
+		expect(p.parse("Hld 1:1").osis()).toEqual("Song.1.1", "parsing: 'Hld 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HOHELIED SALOMONIS 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HOHESLIED SALOMOS 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HOHES LIED 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HOHESLIED 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HOHELIED 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("SONG 1:1").osis()).toEqual("Song.1.1")
-		expect(p.parse("HLD 1:1").osis()).toEqual("Song.1.1")
+		expect(p.parse("HOHESLIED SALOMONIS 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHESLIED SALOMONIS 1:1'")
+		expect(p.parse("HOHELIED SALOMONIS 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHELIED SALOMONIS 1:1'")
+		expect(p.parse("HOHESLIED SALOMOS 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHESLIED SALOMOS 1:1'")
+		expect(p.parse("HOHELIED SALOMOS 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHELIED SALOMOS 1:1'")
+		expect(p.parse("HOHES LIED 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHES LIED 1:1'")
+		expect(p.parse("HOHESLIED 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHESLIED 1:1'")
+		expect(p.parse("HOHELIED 1:1").osis()).toEqual("Song.1.1", "parsing: 'HOHELIED 1:1'")
+		expect(p.parse("SONG 1:1").osis()).toEqual("Song.1.1", "parsing: 'SONG 1:1'")
+		expect(p.parse("HLD 1:1").osis()).toEqual("Song.1.1", "parsing: 'HLD 1:1'")
 		;
       return true;
     });
@@ -1208,13 +1416,13 @@
     });
     return it("should handle book: Jer (de)", function() {
       
-		expect(p.parse("Jeremias 1:1").osis()).toEqual("Jer.1.1")
-		expect(p.parse("Jeremia 1:1").osis()).toEqual("Jer.1.1")
-		expect(p.parse("Jer 1:1").osis()).toEqual("Jer.1.1")
+		expect(p.parse("Jeremias 1:1").osis()).toEqual("Jer.1.1", "parsing: 'Jeremias 1:1'")
+		expect(p.parse("Jeremia 1:1").osis()).toEqual("Jer.1.1", "parsing: 'Jeremia 1:1'")
+		expect(p.parse("Jer 1:1").osis()).toEqual("Jer.1.1", "parsing: 'Jer 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JEREMIAS 1:1").osis()).toEqual("Jer.1.1")
-		expect(p.parse("JEREMIA 1:1").osis()).toEqual("Jer.1.1")
-		expect(p.parse("JER 1:1").osis()).toEqual("Jer.1.1")
+		expect(p.parse("JEREMIAS 1:1").osis()).toEqual("Jer.1.1", "parsing: 'JEREMIAS 1:1'")
+		expect(p.parse("JEREMIA 1:1").osis()).toEqual("Jer.1.1", "parsing: 'JEREMIA 1:1'")
+		expect(p.parse("JER 1:1").osis()).toEqual("Jer.1.1", "parsing: 'JER 1:1'")
 		;
       return true;
     });
@@ -1235,17 +1443,19 @@
     });
     return it("should handle book: Ezek (de)", function() {
       
-		expect(p.parse("Ezechiel 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("Hesekiel 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("Ezek 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("Hes 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("Ez 1:1").osis()).toEqual("Ezek.1.1")
+		expect(p.parse("Ezechiel 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Ezechiel 1:1'")
+		expect(p.parse("Hesekiel 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Hesekiel 1:1'")
+		expect(p.parse("Hesek 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Hesek 1:1'")
+		expect(p.parse("Ezek 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Ezek 1:1'")
+		expect(p.parse("Hes 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Hes 1:1'")
+		expect(p.parse("Ez 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'Ez 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("EZECHIEL 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("HESEKIEL 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("EZEK 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("HES 1:1").osis()).toEqual("Ezek.1.1")
-		expect(p.parse("EZ 1:1").osis()).toEqual("Ezek.1.1")
+		expect(p.parse("EZECHIEL 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'EZECHIEL 1:1'")
+		expect(p.parse("HESEKIEL 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'HESEKIEL 1:1'")
+		expect(p.parse("HESEK 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'HESEK 1:1'")
+		expect(p.parse("EZEK 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'EZEK 1:1'")
+		expect(p.parse("HES 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'HES 1:1'")
+		expect(p.parse("EZ 1:1").osis()).toEqual("Ezek.1.1", "parsing: 'EZ 1:1'")
 		;
       return true;
     });
@@ -1266,11 +1476,11 @@
     });
     return it("should handle book: Dan (de)", function() {
       
-		expect(p.parse("Daniel 1:1").osis()).toEqual("Dan.1.1")
-		expect(p.parse("Dan 1:1").osis()).toEqual("Dan.1.1")
+		expect(p.parse("Daniel 1:1").osis()).toEqual("Dan.1.1", "parsing: 'Daniel 1:1'")
+		expect(p.parse("Dan 1:1").osis()).toEqual("Dan.1.1", "parsing: 'Dan 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DANIEL 1:1").osis()).toEqual("Dan.1.1")
-		expect(p.parse("DAN 1:1").osis()).toEqual("Dan.1.1")
+		expect(p.parse("DANIEL 1:1").osis()).toEqual("Dan.1.1", "parsing: 'DANIEL 1:1'")
+		expect(p.parse("DAN 1:1").osis()).toEqual("Dan.1.1", "parsing: 'DAN 1:1'")
 		;
       return true;
     });
@@ -1291,13 +1501,11 @@
     });
     return it("should handle book: Hos (de)", function() {
       
-		expect(p.parse("Hosea 1:1").osis()).toEqual("Hos.1.1")
-		expect(p.parse("Osee 1:1").osis()).toEqual("Hos.1.1")
-		expect(p.parse("Hos 1:1").osis()).toEqual("Hos.1.1")
+		expect(p.parse("Hosea 1:1").osis()).toEqual("Hos.1.1", "parsing: 'Hosea 1:1'")
+		expect(p.parse("Hos 1:1").osis()).toEqual("Hos.1.1", "parsing: 'Hos 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HOSEA 1:1").osis()).toEqual("Hos.1.1")
-		expect(p.parse("OSEE 1:1").osis()).toEqual("Hos.1.1")
-		expect(p.parse("HOS 1:1").osis()).toEqual("Hos.1.1")
+		expect(p.parse("HOSEA 1:1").osis()).toEqual("Hos.1.1", "parsing: 'HOSEA 1:1'")
+		expect(p.parse("HOS 1:1").osis()).toEqual("Hos.1.1", "parsing: 'HOS 1:1'")
 		;
       return true;
     });
@@ -1318,9 +1526,9 @@
     });
     return it("should handle book: Joel (de)", function() {
       
-		expect(p.parse("Joel 1:1").osis()).toEqual("Joel.1.1")
+		expect(p.parse("Joel 1:1").osis()).toEqual("Joel.1.1", "parsing: 'Joel 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JOEL 1:1").osis()).toEqual("Joel.1.1")
+		expect(p.parse("JOEL 1:1").osis()).toEqual("Joel.1.1", "parsing: 'JOEL 1:1'")
 		;
       return true;
     });
@@ -1341,11 +1549,11 @@
     });
     return it("should handle book: Amos (de)", function() {
       
-		expect(p.parse("Amos 1:1").osis()).toEqual("Amos.1.1")
-		expect(p.parse("Am 1:1").osis()).toEqual("Amos.1.1")
+		expect(p.parse("Amos 1:1").osis()).toEqual("Amos.1.1", "parsing: 'Amos 1:1'")
+		expect(p.parse("Am 1:1").osis()).toEqual("Amos.1.1", "parsing: 'Am 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("AMOS 1:1").osis()).toEqual("Amos.1.1")
-		expect(p.parse("AM 1:1").osis()).toEqual("Amos.1.1")
+		expect(p.parse("AMOS 1:1").osis()).toEqual("Amos.1.1", "parsing: 'AMOS 1:1'")
+		expect(p.parse("AM 1:1").osis()).toEqual("Amos.1.1", "parsing: 'AM 1:1'")
 		;
       return true;
     });
@@ -1366,15 +1574,15 @@
     });
     return it("should handle book: Obad (de)", function() {
       
-		expect(p.parse("Abdias 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("Obadja 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("Obad 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("Obd 1:1").osis()).toEqual("Obad.1.1")
+		expect(p.parse("Abdias 1:1").osis()).toEqual("Obad.1.1", "parsing: 'Abdias 1:1'")
+		expect(p.parse("Obadja 1:1").osis()).toEqual("Obad.1.1", "parsing: 'Obadja 1:1'")
+		expect(p.parse("Obad 1:1").osis()).toEqual("Obad.1.1", "parsing: 'Obad 1:1'")
+		expect(p.parse("Obd 1:1").osis()).toEqual("Obad.1.1", "parsing: 'Obd 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ABDIAS 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("OBADJA 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("OBAD 1:1").osis()).toEqual("Obad.1.1")
-		expect(p.parse("OBD 1:1").osis()).toEqual("Obad.1.1")
+		expect(p.parse("ABDIAS 1:1").osis()).toEqual("Obad.1.1", "parsing: 'ABDIAS 1:1'")
+		expect(p.parse("OBADJA 1:1").osis()).toEqual("Obad.1.1", "parsing: 'OBADJA 1:1'")
+		expect(p.parse("OBAD 1:1").osis()).toEqual("Obad.1.1", "parsing: 'OBAD 1:1'")
+		expect(p.parse("OBD 1:1").osis()).toEqual("Obad.1.1", "parsing: 'OBD 1:1'")
 		;
       return true;
     });
@@ -1395,13 +1603,13 @@
     });
     return it("should handle book: Jonah (de)", function() {
       
-		expect(p.parse("Jonah 1:1").osis()).toEqual("Jonah.1.1")
-		expect(p.parse("Jonas 1:1").osis()).toEqual("Jonah.1.1")
-		expect(p.parse("Jona 1:1").osis()).toEqual("Jonah.1.1")
+		expect(p.parse("Jonah 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'Jonah 1:1'")
+		expect(p.parse("Jonas 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'Jonas 1:1'")
+		expect(p.parse("Jona 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'Jona 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JONAH 1:1").osis()).toEqual("Jonah.1.1")
-		expect(p.parse("JONAS 1:1").osis()).toEqual("Jonah.1.1")
-		expect(p.parse("JONA 1:1").osis()).toEqual("Jonah.1.1")
+		expect(p.parse("JONAH 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'JONAH 1:1'")
+		expect(p.parse("JONAS 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'JONAS 1:1'")
+		expect(p.parse("JONA 1:1").osis()).toEqual("Jonah.1.1", "parsing: 'JONA 1:1'")
 		;
       return true;
     });
@@ -1422,17 +1630,21 @@
     });
     return it("should handle book: Mic (de)", function() {
       
-		expect(p.parse("Michaas 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("Michäas 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("Micha 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("Mic 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("Mi 1:1").osis()).toEqual("Mic.1.1")
+		expect(p.parse("Michaeas 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Michaeas 1:1'")
+		expect(p.parse("Michaas 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Michaas 1:1'")
+		expect(p.parse("Michäas 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Michäas 1:1'")
+		expect(p.parse("Micha 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Micha 1:1'")
+		expect(p.parse("Mich 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Mich 1:1'")
+		expect(p.parse("Mic 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Mic 1:1'")
+		expect(p.parse("Mi 1:1").osis()).toEqual("Mic.1.1", "parsing: 'Mi 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("MICHAAS 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("MICHÄAS 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("MICHA 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("MIC 1:1").osis()).toEqual("Mic.1.1")
-		expect(p.parse("MI 1:1").osis()).toEqual("Mic.1.1")
+		expect(p.parse("MICHAEAS 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICHAEAS 1:1'")
+		expect(p.parse("MICHAAS 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICHAAS 1:1'")
+		expect(p.parse("MICHÄAS 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICHÄAS 1:1'")
+		expect(p.parse("MICHA 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICHA 1:1'")
+		expect(p.parse("MICH 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MICH 1:1'")
+		expect(p.parse("MIC 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MIC 1:1'")
+		expect(p.parse("MI 1:1").osis()).toEqual("Mic.1.1", "parsing: 'MI 1:1'")
 		;
       return true;
     });
@@ -1453,11 +1665,11 @@
     });
     return it("should handle book: Nah (de)", function() {
       
-		expect(p.parse("Nahum 1:1").osis()).toEqual("Nah.1.1")
-		expect(p.parse("Nah 1:1").osis()).toEqual("Nah.1.1")
+		expect(p.parse("Nahum 1:1").osis()).toEqual("Nah.1.1", "parsing: 'Nahum 1:1'")
+		expect(p.parse("Nah 1:1").osis()).toEqual("Nah.1.1", "parsing: 'Nah 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("NAHUM 1:1").osis()).toEqual("Nah.1.1")
-		expect(p.parse("NAH 1:1").osis()).toEqual("Nah.1.1")
+		expect(p.parse("NAHUM 1:1").osis()).toEqual("Nah.1.1", "parsing: 'NAHUM 1:1'")
+		expect(p.parse("NAH 1:1").osis()).toEqual("Nah.1.1", "parsing: 'NAH 1:1'")
 		;
       return true;
     });
@@ -1478,11 +1690,11 @@
     });
     return it("should handle book: Hab (de)", function() {
       
-		expect(p.parse("Habakuk 1:1").osis()).toEqual("Hab.1.1")
-		expect(p.parse("Hab 1:1").osis()).toEqual("Hab.1.1")
+		expect(p.parse("Habakuk 1:1").osis()).toEqual("Hab.1.1", "parsing: 'Habakuk 1:1'")
+		expect(p.parse("Hab 1:1").osis()).toEqual("Hab.1.1", "parsing: 'Hab 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HABAKUK 1:1").osis()).toEqual("Hab.1.1")
-		expect(p.parse("HAB 1:1").osis()).toEqual("Hab.1.1")
+		expect(p.parse("HABAKUK 1:1").osis()).toEqual("Hab.1.1", "parsing: 'HABAKUK 1:1'")
+		expect(p.parse("HAB 1:1").osis()).toEqual("Hab.1.1", "parsing: 'HAB 1:1'")
 		;
       return true;
     });
@@ -1503,19 +1715,15 @@
     });
     return it("should handle book: Zeph (de)", function() {
       
-		expect(p.parse("Sophonias 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Zephanja 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Zefanja 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Soph 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Zeph 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("Zef 1:1").osis()).toEqual("Zeph.1.1")
+		expect(p.parse("Zephanja 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'Zephanja 1:1'")
+		expect(p.parse("Zefanja 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'Zefanja 1:1'")
+		expect(p.parse("Zeph 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'Zeph 1:1'")
+		expect(p.parse("Zef 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'Zef 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("SOPHONIAS 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("ZEPHANJA 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("ZEFANJA 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("SOPH 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("ZEPH 1:1").osis()).toEqual("Zeph.1.1")
-		expect(p.parse("ZEF 1:1").osis()).toEqual("Zeph.1.1")
+		expect(p.parse("ZEPHANJA 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'ZEPHANJA 1:1'")
+		expect(p.parse("ZEFANJA 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'ZEFANJA 1:1'")
+		expect(p.parse("ZEPH 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'ZEPH 1:1'")
+		expect(p.parse("ZEF 1:1").osis()).toEqual("Zeph.1.1", "parsing: 'ZEF 1:1'")
 		;
       return true;
     });
@@ -1536,19 +1744,13 @@
     });
     return it("should handle book: Hag (de)", function() {
       
-		expect(p.parse("Aggaus 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Aggäus 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Haggai 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Agg 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Hag 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("Ag 1:1").osis()).toEqual("Hag.1.1")
+		expect(p.parse("Haggai 1:1").osis()).toEqual("Hag.1.1", "parsing: 'Haggai 1:1'")
+		expect(p.parse("Hagg 1:1").osis()).toEqual("Hag.1.1", "parsing: 'Hagg 1:1'")
+		expect(p.parse("Hag 1:1").osis()).toEqual("Hag.1.1", "parsing: 'Hag 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("AGGAUS 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("AGGÄUS 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("HAGGAI 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("AGG 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("HAG 1:1").osis()).toEqual("Hag.1.1")
-		expect(p.parse("AG 1:1").osis()).toEqual("Hag.1.1")
+		expect(p.parse("HAGGAI 1:1").osis()).toEqual("Hag.1.1", "parsing: 'HAGGAI 1:1'")
+		expect(p.parse("HAGG 1:1").osis()).toEqual("Hag.1.1", "parsing: 'HAGG 1:1'")
+		expect(p.parse("HAG 1:1").osis()).toEqual("Hag.1.1", "parsing: 'HAG 1:1'")
 		;
       return true;
     });
@@ -1569,15 +1771,15 @@
     });
     return it("should handle book: Zech (de)", function() {
       
-		expect(p.parse("Zacharias 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("Sacharja 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("Sach 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("Zech 1:1").osis()).toEqual("Zech.1.1")
+		expect(p.parse("Zacharias 1:1").osis()).toEqual("Zech.1.1", "parsing: 'Zacharias 1:1'")
+		expect(p.parse("Sacharja 1:1").osis()).toEqual("Zech.1.1", "parsing: 'Sacharja 1:1'")
+		expect(p.parse("Sach 1:1").osis()).toEqual("Zech.1.1", "parsing: 'Sach 1:1'")
+		expect(p.parse("Zech 1:1").osis()).toEqual("Zech.1.1", "parsing: 'Zech 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZACHARIAS 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("SACHARJA 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("SACH 1:1").osis()).toEqual("Zech.1.1")
-		expect(p.parse("ZECH 1:1").osis()).toEqual("Zech.1.1")
+		expect(p.parse("ZACHARIAS 1:1").osis()).toEqual("Zech.1.1", "parsing: 'ZACHARIAS 1:1'")
+		expect(p.parse("SACHARJA 1:1").osis()).toEqual("Zech.1.1", "parsing: 'SACHARJA 1:1'")
+		expect(p.parse("SACH 1:1").osis()).toEqual("Zech.1.1", "parsing: 'SACH 1:1'")
+		expect(p.parse("ZECH 1:1").osis()).toEqual("Zech.1.1", "parsing: 'ZECH 1:1'")
 		;
       return true;
     });
@@ -1598,13 +1800,13 @@
     });
     return it("should handle book: Mal (de)", function() {
       
-		expect(p.parse("Malachias 1:1").osis()).toEqual("Mal.1.1")
-		expect(p.parse("Maleachi 1:1").osis()).toEqual("Mal.1.1")
-		expect(p.parse("Mal 1:1").osis()).toEqual("Mal.1.1")
+		expect(p.parse("Malachias 1:1").osis()).toEqual("Mal.1.1", "parsing: 'Malachias 1:1'")
+		expect(p.parse("Maleachi 1:1").osis()).toEqual("Mal.1.1", "parsing: 'Maleachi 1:1'")
+		expect(p.parse("Mal 1:1").osis()).toEqual("Mal.1.1", "parsing: 'Mal 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("MALACHIAS 1:1").osis()).toEqual("Mal.1.1")
-		expect(p.parse("MALEACHI 1:1").osis()).toEqual("Mal.1.1")
-		expect(p.parse("MAL 1:1").osis()).toEqual("Mal.1.1")
+		expect(p.parse("MALACHIAS 1:1").osis()).toEqual("Mal.1.1", "parsing: 'MALACHIAS 1:1'")
+		expect(p.parse("MALEACHI 1:1").osis()).toEqual("Mal.1.1", "parsing: 'MALEACHI 1:1'")
+		expect(p.parse("MAL 1:1").osis()).toEqual("Mal.1.1", "parsing: 'MAL 1:1'")
 		;
       return true;
     });
@@ -1625,15 +1827,35 @@
     });
     return it("should handle book: Matt (de)", function() {
       
-		expect(p.parse("Matthaus 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Matthäus 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Matt 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("Mt 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("Das Evangelium nach Matthaeus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Das Evangelium nach Matthaeus 1:1'")
+		expect(p.parse("Das Evangelium nach Matthaus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Das Evangelium nach Matthaus 1:1'")
+		expect(p.parse("Das Evangelium nach Matthäus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Das Evangelium nach Matthäus 1:1'")
+		expect(p.parse(" Evangelium nach Matthaeus 1:1").osis()).toEqual("Matt.1.1", "parsing: ' Evangelium nach Matthaeus 1:1'")
+		expect(p.parse(" Evangelium nach Matthaus 1:1").osis()).toEqual("Matt.1.1", "parsing: ' Evangelium nach Matthaus 1:1'")
+		expect(p.parse(" Evangelium nach Matthäus 1:1").osis()).toEqual("Matt.1.1", "parsing: ' Evangelium nach Matthäus 1:1'")
+		expect(p.parse("Matthaeusevangelium 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthaeusevangelium 1:1'")
+		expect(p.parse("Matthausevangelium 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthausevangelium 1:1'")
+		expect(p.parse("Matthäusevangelium 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthäusevangelium 1:1'")
+		expect(p.parse("Matthaeus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthaeus 1:1'")
+		expect(p.parse("Matthaus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthaus 1:1'")
+		expect(p.parse("Matthäus 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matthäus 1:1'")
+		expect(p.parse("Matt 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Matt 1:1'")
+		expect(p.parse("Mt 1:1").osis()).toEqual("Matt.1.1", "parsing: 'Mt 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("MATTHAUS 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("MATTHÄUS 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("MATT 1:1").osis()).toEqual("Matt.1.1")
-		expect(p.parse("MT 1:1").osis()).toEqual("Matt.1.1")
+		expect(p.parse("DAS EVANGELIUM NACH MATTHAEUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'DAS EVANGELIUM NACH MATTHAEUS 1:1'")
+		expect(p.parse("DAS EVANGELIUM NACH MATTHAUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'DAS EVANGELIUM NACH MATTHAUS 1:1'")
+		expect(p.parse("DAS EVANGELIUM NACH MATTHÄUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'DAS EVANGELIUM NACH MATTHÄUS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH MATTHAEUS 1:1").osis()).toEqual("Matt.1.1", "parsing: ' EVANGELIUM NACH MATTHAEUS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH MATTHAUS 1:1").osis()).toEqual("Matt.1.1", "parsing: ' EVANGELIUM NACH MATTHAUS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH MATTHÄUS 1:1").osis()).toEqual("Matt.1.1", "parsing: ' EVANGELIUM NACH MATTHÄUS 1:1'")
+		expect(p.parse("MATTHAEUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHAEUSEVANGELIUM 1:1'")
+		expect(p.parse("MATTHAUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHAUSEVANGELIUM 1:1'")
+		expect(p.parse("MATTHÄUSEVANGELIUM 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHÄUSEVANGELIUM 1:1'")
+		expect(p.parse("MATTHAEUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHAEUS 1:1'")
+		expect(p.parse("MATTHAUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHAUS 1:1'")
+		expect(p.parse("MATTHÄUS 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATTHÄUS 1:1'")
+		expect(p.parse("MATT 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MATT 1:1'")
+		expect(p.parse("MT 1:1").osis()).toEqual("Matt.1.1", "parsing: 'MT 1:1'")
 		;
       return true;
     });
@@ -1654,13 +1876,19 @@
     });
     return it("should handle book: Mark (de)", function() {
       
-		expect(p.parse("Markus 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("Mark 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("Mk 1:1").osis()).toEqual("Mark.1.1")
+		expect(p.parse("Das Evangelium nach Markus 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Das Evangelium nach Markus 1:1'")
+		expect(p.parse(" Evangelium nach Markus 1:1").osis()).toEqual("Mark.1.1", "parsing: ' Evangelium nach Markus 1:1'")
+		expect(p.parse("Markusevangelium 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Markusevangelium 1:1'")
+		expect(p.parse("Markus 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Markus 1:1'")
+		expect(p.parse("Mark 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Mark 1:1'")
+		expect(p.parse("Mk 1:1").osis()).toEqual("Mark.1.1", "parsing: 'Mk 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("MARKUS 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("MARK 1:1").osis()).toEqual("Mark.1.1")
-		expect(p.parse("MK 1:1").osis()).toEqual("Mark.1.1")
+		expect(p.parse("DAS EVANGELIUM NACH MARKUS 1:1").osis()).toEqual("Mark.1.1", "parsing: 'DAS EVANGELIUM NACH MARKUS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH MARKUS 1:1").osis()).toEqual("Mark.1.1", "parsing: ' EVANGELIUM NACH MARKUS 1:1'")
+		expect(p.parse("MARKUSEVANGELIUM 1:1").osis()).toEqual("Mark.1.1", "parsing: 'MARKUSEVANGELIUM 1:1'")
+		expect(p.parse("MARKUS 1:1").osis()).toEqual("Mark.1.1", "parsing: 'MARKUS 1:1'")
+		expect(p.parse("MARK 1:1").osis()).toEqual("Mark.1.1", "parsing: 'MARK 1:1'")
+		expect(p.parse("MK 1:1").osis()).toEqual("Mark.1.1", "parsing: 'MK 1:1'")
 		;
       return true;
     });
@@ -1681,13 +1909,21 @@
     });
     return it("should handle book: Luke (de)", function() {
       
-		expect(p.parse("Lukas 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("Luke 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("Lk 1:1").osis()).toEqual("Luke.1.1")
+		expect(p.parse("Das Evangelium nach Lukas 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Das Evangelium nach Lukas 1:1'")
+		expect(p.parse(" Evangelium nach Lukas 1:1").osis()).toEqual("Luke.1.1", "parsing: ' Evangelium nach Lukas 1:1'")
+		expect(p.parse("Lukasevangelium 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Lukasevangelium 1:1'")
+		expect(p.parse("Lukas 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Lukas 1:1'")
+		expect(p.parse("Luke 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Luke 1:1'")
+		expect(p.parse("Luk 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Luk 1:1'")
+		expect(p.parse("Lk 1:1").osis()).toEqual("Luke.1.1", "parsing: 'Lk 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("LUKAS 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("LUKE 1:1").osis()).toEqual("Luke.1.1")
-		expect(p.parse("LK 1:1").osis()).toEqual("Luke.1.1")
+		expect(p.parse("DAS EVANGELIUM NACH LUKAS 1:1").osis()).toEqual("Luke.1.1", "parsing: 'DAS EVANGELIUM NACH LUKAS 1:1'")
+		expect(p.parse(" EVANGELIUM NACH LUKAS 1:1").osis()).toEqual("Luke.1.1", "parsing: ' EVANGELIUM NACH LUKAS 1:1'")
+		expect(p.parse("LUKASEVANGELIUM 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LUKASEVANGELIUM 1:1'")
+		expect(p.parse("LUKAS 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LUKAS 1:1'")
+		expect(p.parse("LUKE 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LUKE 1:1'")
+		expect(p.parse("LUK 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LUK 1:1'")
+		expect(p.parse("LK 1:1").osis()).toEqual("Luke.1.1", "parsing: 'LK 1:1'")
 		;
       return true;
     });
@@ -1708,19 +1944,29 @@
     });
     return it("should handle book: 1John (de)", function() {
       
-		expect(p.parse("Erste Johannes 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1. Johannes 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1 Johannes 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1. Joh 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1 Joh 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1John 1:1").osis()).toEqual("1John.1.1")
+		expect(p.parse("Ersten Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: 'Ersten Johannes 1:1'")
+		expect(p.parse("Erster Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: 'Erster Johannes 1:1'")
+		expect(p.parse("Erstes Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: 'Erstes Johannes 1:1'")
+		expect(p.parse("Erste Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: 'Erste Johannes 1:1'")
+		expect(p.parse("1. Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: '1. Johannes 1:1'")
+		expect(p.parse("1 Johannes 1:1").osis()).toEqual("1John.1.1", "parsing: '1 Johannes 1:1'")
+		expect(p.parse("1. Joh 1:1").osis()).toEqual("1John.1.1", "parsing: '1. Joh 1:1'")
+		expect(p.parse("1 Joh 1:1").osis()).toEqual("1John.1.1", "parsing: '1 Joh 1:1'")
+		expect(p.parse("1. Jo 1:1").osis()).toEqual("1John.1.1", "parsing: '1. Jo 1:1'")
+		expect(p.parse("1John 1:1").osis()).toEqual("1John.1.1", "parsing: '1John 1:1'")
+		expect(p.parse("1 Jo 1:1").osis()).toEqual("1John.1.1", "parsing: '1 Jo 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTE JOHANNES 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1. JOHANNES 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1 JOHANNES 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1. JOH 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1 JOH 1:1").osis()).toEqual("1John.1.1")
-		expect(p.parse("1JOHN 1:1").osis()).toEqual("1John.1.1")
+		expect(p.parse("ERSTEN JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: 'ERSTEN JOHANNES 1:1'")
+		expect(p.parse("ERSTER JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: 'ERSTER JOHANNES 1:1'")
+		expect(p.parse("ERSTES JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: 'ERSTES JOHANNES 1:1'")
+		expect(p.parse("ERSTE JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: 'ERSTE JOHANNES 1:1'")
+		expect(p.parse("1. JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: '1. JOHANNES 1:1'")
+		expect(p.parse("1 JOHANNES 1:1").osis()).toEqual("1John.1.1", "parsing: '1 JOHANNES 1:1'")
+		expect(p.parse("1. JOH 1:1").osis()).toEqual("1John.1.1", "parsing: '1. JOH 1:1'")
+		expect(p.parse("1 JOH 1:1").osis()).toEqual("1John.1.1", "parsing: '1 JOH 1:1'")
+		expect(p.parse("1. JO 1:1").osis()).toEqual("1John.1.1", "parsing: '1. JO 1:1'")
+		expect(p.parse("1JOHN 1:1").osis()).toEqual("1John.1.1", "parsing: '1JOHN 1:1'")
+		expect(p.parse("1 JO 1:1").osis()).toEqual("1John.1.1", "parsing: '1 JO 1:1'")
 		;
       return true;
     });
@@ -1741,19 +1987,29 @@
     });
     return it("should handle book: 2John (de)", function() {
       
-		expect(p.parse("Zweite Johannes 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2. Johannes 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2 Johannes 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2. Joh 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2 Joh 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2John 1:1").osis()).toEqual("2John.1.1")
+		expect(p.parse("Zweiten Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: 'Zweiten Johannes 1:1'")
+		expect(p.parse("Zweiter Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: 'Zweiter Johannes 1:1'")
+		expect(p.parse("Zweites Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: 'Zweites Johannes 1:1'")
+		expect(p.parse("Zweite Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: 'Zweite Johannes 1:1'")
+		expect(p.parse("2. Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: '2. Johannes 1:1'")
+		expect(p.parse("2 Johannes 1:1").osis()).toEqual("2John.1.1", "parsing: '2 Johannes 1:1'")
+		expect(p.parse("2. Joh 1:1").osis()).toEqual("2John.1.1", "parsing: '2. Joh 1:1'")
+		expect(p.parse("2 Joh 1:1").osis()).toEqual("2John.1.1", "parsing: '2 Joh 1:1'")
+		expect(p.parse("2. Jo 1:1").osis()).toEqual("2John.1.1", "parsing: '2. Jo 1:1'")
+		expect(p.parse("2John 1:1").osis()).toEqual("2John.1.1", "parsing: '2John 1:1'")
+		expect(p.parse("2 Jo 1:1").osis()).toEqual("2John.1.1", "parsing: '2 Jo 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITE JOHANNES 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2. JOHANNES 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2 JOHANNES 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2. JOH 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2 JOH 1:1").osis()).toEqual("2John.1.1")
-		expect(p.parse("2JOHN 1:1").osis()).toEqual("2John.1.1")
+		expect(p.parse("ZWEITEN JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: 'ZWEITEN JOHANNES 1:1'")
+		expect(p.parse("ZWEITER JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: 'ZWEITER JOHANNES 1:1'")
+		expect(p.parse("ZWEITES JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: 'ZWEITES JOHANNES 1:1'")
+		expect(p.parse("ZWEITE JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: 'ZWEITE JOHANNES 1:1'")
+		expect(p.parse("2. JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: '2. JOHANNES 1:1'")
+		expect(p.parse("2 JOHANNES 1:1").osis()).toEqual("2John.1.1", "parsing: '2 JOHANNES 1:1'")
+		expect(p.parse("2. JOH 1:1").osis()).toEqual("2John.1.1", "parsing: '2. JOH 1:1'")
+		expect(p.parse("2 JOH 1:1").osis()).toEqual("2John.1.1", "parsing: '2 JOH 1:1'")
+		expect(p.parse("2. JO 1:1").osis()).toEqual("2John.1.1", "parsing: '2. JO 1:1'")
+		expect(p.parse("2JOHN 1:1").osis()).toEqual("2John.1.1", "parsing: '2JOHN 1:1'")
+		expect(p.parse("2 JO 1:1").osis()).toEqual("2John.1.1", "parsing: '2 JO 1:1'")
 		;
       return true;
     });
@@ -1774,19 +2030,29 @@
     });
     return it("should handle book: 3John (de)", function() {
       
-		expect(p.parse("Dritte Johannes 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3. Johannes 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3 Johannes 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3. Joh 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3 Joh 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3John 1:1").osis()).toEqual("3John.1.1")
+		expect(p.parse("Dritten Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: 'Dritten Johannes 1:1'")
+		expect(p.parse("Dritter Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: 'Dritter Johannes 1:1'")
+		expect(p.parse("Drittes Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: 'Drittes Johannes 1:1'")
+		expect(p.parse("Dritte Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: 'Dritte Johannes 1:1'")
+		expect(p.parse("3. Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: '3. Johannes 1:1'")
+		expect(p.parse("3 Johannes 1:1").osis()).toEqual("3John.1.1", "parsing: '3 Johannes 1:1'")
+		expect(p.parse("3. Joh 1:1").osis()).toEqual("3John.1.1", "parsing: '3. Joh 1:1'")
+		expect(p.parse("3 Joh 1:1").osis()).toEqual("3John.1.1", "parsing: '3 Joh 1:1'")
+		expect(p.parse("3. Jo 1:1").osis()).toEqual("3John.1.1", "parsing: '3. Jo 1:1'")
+		expect(p.parse("3John 1:1").osis()).toEqual("3John.1.1", "parsing: '3John 1:1'")
+		expect(p.parse("3 Jo 1:1").osis()).toEqual("3John.1.1", "parsing: '3 Jo 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("DRITTE JOHANNES 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3. JOHANNES 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3 JOHANNES 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3. JOH 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3 JOH 1:1").osis()).toEqual("3John.1.1")
-		expect(p.parse("3JOHN 1:1").osis()).toEqual("3John.1.1")
+		expect(p.parse("DRITTEN JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: 'DRITTEN JOHANNES 1:1'")
+		expect(p.parse("DRITTER JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: 'DRITTER JOHANNES 1:1'")
+		expect(p.parse("DRITTES JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: 'DRITTES JOHANNES 1:1'")
+		expect(p.parse("DRITTE JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: 'DRITTE JOHANNES 1:1'")
+		expect(p.parse("3. JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: '3. JOHANNES 1:1'")
+		expect(p.parse("3 JOHANNES 1:1").osis()).toEqual("3John.1.1", "parsing: '3 JOHANNES 1:1'")
+		expect(p.parse("3. JOH 1:1").osis()).toEqual("3John.1.1", "parsing: '3. JOH 1:1'")
+		expect(p.parse("3 JOH 1:1").osis()).toEqual("3John.1.1", "parsing: '3 JOH 1:1'")
+		expect(p.parse("3. JO 1:1").osis()).toEqual("3John.1.1", "parsing: '3. JO 1:1'")
+		expect(p.parse("3JOHN 1:1").osis()).toEqual("3John.1.1", "parsing: '3JOHN 1:1'")
+		expect(p.parse("3 JO 1:1").osis()).toEqual("3John.1.1", "parsing: '3 JO 1:1'")
 		;
       return true;
     });
@@ -1807,13 +2073,19 @@
     });
     return it("should handle book: John (de)", function() {
       
-		expect(p.parse("Johannes 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("John 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("Joh 1:1").osis()).toEqual("John.1.1")
+		expect(p.parse("Das Evangelium nach Johannes 1:1").osis()).toEqual("John.1.1", "parsing: 'Das Evangelium nach Johannes 1:1'")
+		expect(p.parse(" Evangelium nach Johannes 1:1").osis()).toEqual("John.1.1", "parsing: ' Evangelium nach Johannes 1:1'")
+		expect(p.parse("Johannesevangelium 1:1").osis()).toEqual("John.1.1", "parsing: 'Johannesevangelium 1:1'")
+		expect(p.parse("Johannes 1:1").osis()).toEqual("John.1.1", "parsing: 'Johannes 1:1'")
+		expect(p.parse("John 1:1").osis()).toEqual("John.1.1", "parsing: 'John 1:1'")
+		expect(p.parse("Joh 1:1").osis()).toEqual("John.1.1", "parsing: 'Joh 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JOHANNES 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("JOHN 1:1").osis()).toEqual("John.1.1")
-		expect(p.parse("JOH 1:1").osis()).toEqual("John.1.1")
+		expect(p.parse("DAS EVANGELIUM NACH JOHANNES 1:1").osis()).toEqual("John.1.1", "parsing: 'DAS EVANGELIUM NACH JOHANNES 1:1'")
+		expect(p.parse(" EVANGELIUM NACH JOHANNES 1:1").osis()).toEqual("John.1.1", "parsing: ' EVANGELIUM NACH JOHANNES 1:1'")
+		expect(p.parse("JOHANNESEVANGELIUM 1:1").osis()).toEqual("John.1.1", "parsing: 'JOHANNESEVANGELIUM 1:1'")
+		expect(p.parse("JOHANNES 1:1").osis()).toEqual("John.1.1", "parsing: 'JOHANNES 1:1'")
+		expect(p.parse("JOHN 1:1").osis()).toEqual("John.1.1", "parsing: 'JOHN 1:1'")
+		expect(p.parse("JOH 1:1").osis()).toEqual("John.1.1", "parsing: 'JOH 1:1'")
 		;
       return true;
     });
@@ -1834,13 +2106,13 @@
     });
     return it("should handle book: Acts (de)", function() {
       
-		expect(p.parse("Apostelgeschichte 1:1").osis()).toEqual("Acts.1.1")
-		expect(p.parse("Acts 1:1").osis()).toEqual("Acts.1.1")
-		expect(p.parse("Apg 1:1").osis()).toEqual("Acts.1.1")
+		expect(p.parse("Apostelgeschichte 1:1").osis()).toEqual("Acts.1.1", "parsing: 'Apostelgeschichte 1:1'")
+		expect(p.parse("Acts 1:1").osis()).toEqual("Acts.1.1", "parsing: 'Acts 1:1'")
+		expect(p.parse("Apg 1:1").osis()).toEqual("Acts.1.1", "parsing: 'Apg 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("APOSTELGESCHICHTE 1:1").osis()).toEqual("Acts.1.1")
-		expect(p.parse("ACTS 1:1").osis()).toEqual("Acts.1.1")
-		expect(p.parse("APG 1:1").osis()).toEqual("Acts.1.1")
+		expect(p.parse("APOSTELGESCHICHTE 1:1").osis()).toEqual("Acts.1.1", "parsing: 'APOSTELGESCHICHTE 1:1'")
+		expect(p.parse("ACTS 1:1").osis()).toEqual("Acts.1.1", "parsing: 'ACTS 1:1'")
+		expect(p.parse("APG 1:1").osis()).toEqual("Acts.1.1", "parsing: 'APG 1:1'")
 		;
       return true;
     });
@@ -1861,17 +2133,21 @@
     });
     return it("should handle book: Rom (de)", function() {
       
-		expect(p.parse("Roemer 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("Romer 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("Römer 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("Rom 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("Röm 1:1").osis()).toEqual("Rom.1.1")
+		expect(p.parse("Roemer 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Roemer 1:1'")
+		expect(p.parse("Romer 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Romer 1:1'")
+		expect(p.parse("Römer 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Römer 1:1'")
+		expect(p.parse("Roem 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Roem 1:1'")
+		expect(p.parse("Rom 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Rom 1:1'")
+		expect(p.parse("Röm 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Röm 1:1'")
+		expect(p.parse("Rm 1:1").osis()).toEqual("Rom.1.1", "parsing: 'Rm 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ROEMER 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("ROMER 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("RÖMER 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("ROM 1:1").osis()).toEqual("Rom.1.1")
-		expect(p.parse("RÖM 1:1").osis()).toEqual("Rom.1.1")
+		expect(p.parse("ROEMER 1:1").osis()).toEqual("Rom.1.1", "parsing: 'ROEMER 1:1'")
+		expect(p.parse("ROMER 1:1").osis()).toEqual("Rom.1.1", "parsing: 'ROMER 1:1'")
+		expect(p.parse("RÖMER 1:1").osis()).toEqual("Rom.1.1", "parsing: 'RÖMER 1:1'")
+		expect(p.parse("ROEM 1:1").osis()).toEqual("Rom.1.1", "parsing: 'ROEM 1:1'")
+		expect(p.parse("ROM 1:1").osis()).toEqual("Rom.1.1", "parsing: 'ROM 1:1'")
+		expect(p.parse("RÖM 1:1").osis()).toEqual("Rom.1.1", "parsing: 'RÖM 1:1'")
+		expect(p.parse("RM 1:1").osis()).toEqual("Rom.1.1", "parsing: 'RM 1:1'")
 		;
       return true;
     });
@@ -1892,19 +2168,25 @@
     });
     return it("should handle book: 2Cor (de)", function() {
       
-		expect(p.parse("Zweite Korinther 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2. Korinther 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2 Korinther 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2. Kor 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2 Kor 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2Cor 1:1").osis()).toEqual("2Cor.1.1")
+		expect(p.parse("Zweiten Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'Zweiten Korinther 1:1'")
+		expect(p.parse("Zweiter Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'Zweiter Korinther 1:1'")
+		expect(p.parse("Zweites Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'Zweites Korinther 1:1'")
+		expect(p.parse("Zweite Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'Zweite Korinther 1:1'")
+		expect(p.parse("2. Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2. Korinther 1:1'")
+		expect(p.parse("2 Korinther 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2 Korinther 1:1'")
+		expect(p.parse("2. Kor 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2. Kor 1:1'")
+		expect(p.parse("2 Kor 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2 Kor 1:1'")
+		expect(p.parse("2Cor 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2Cor 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITE KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2. KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2 KORINTHER 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2. KOR 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2 KOR 1:1").osis()).toEqual("2Cor.1.1")
-		expect(p.parse("2COR 1:1").osis()).toEqual("2Cor.1.1")
+		expect(p.parse("ZWEITEN KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'ZWEITEN KORINTHER 1:1'")
+		expect(p.parse("ZWEITER KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'ZWEITER KORINTHER 1:1'")
+		expect(p.parse("ZWEITES KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'ZWEITES KORINTHER 1:1'")
+		expect(p.parse("ZWEITE KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: 'ZWEITE KORINTHER 1:1'")
+		expect(p.parse("2. KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2. KORINTHER 1:1'")
+		expect(p.parse("2 KORINTHER 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2 KORINTHER 1:1'")
+		expect(p.parse("2. KOR 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2. KOR 1:1'")
+		expect(p.parse("2 KOR 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2 KOR 1:1'")
+		expect(p.parse("2COR 1:1").osis()).toEqual("2Cor.1.1", "parsing: '2COR 1:1'")
 		;
       return true;
     });
@@ -1925,19 +2207,25 @@
     });
     return it("should handle book: 1Cor (de)", function() {
       
-		expect(p.parse("Erste Korinther 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1. Korinther 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1 Korinther 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1. Kor 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1 Kor 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1Cor 1:1").osis()).toEqual("1Cor.1.1")
+		expect(p.parse("Ersten Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'Ersten Korinther 1:1'")
+		expect(p.parse("Erster Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'Erster Korinther 1:1'")
+		expect(p.parse("Erstes Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'Erstes Korinther 1:1'")
+		expect(p.parse("Erste Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'Erste Korinther 1:1'")
+		expect(p.parse("1. Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1. Korinther 1:1'")
+		expect(p.parse("1 Korinther 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1 Korinther 1:1'")
+		expect(p.parse("1. Kor 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1. Kor 1:1'")
+		expect(p.parse("1 Kor 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1 Kor 1:1'")
+		expect(p.parse("1Cor 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1Cor 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTE KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1. KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1 KORINTHER 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1. KOR 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1 KOR 1:1").osis()).toEqual("1Cor.1.1")
-		expect(p.parse("1COR 1:1").osis()).toEqual("1Cor.1.1")
+		expect(p.parse("ERSTEN KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'ERSTEN KORINTHER 1:1'")
+		expect(p.parse("ERSTER KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'ERSTER KORINTHER 1:1'")
+		expect(p.parse("ERSTES KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'ERSTES KORINTHER 1:1'")
+		expect(p.parse("ERSTE KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: 'ERSTE KORINTHER 1:1'")
+		expect(p.parse("1. KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1. KORINTHER 1:1'")
+		expect(p.parse("1 KORINTHER 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1 KORINTHER 1:1'")
+		expect(p.parse("1. KOR 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1. KOR 1:1'")
+		expect(p.parse("1 KOR 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1 KOR 1:1'")
+		expect(p.parse("1COR 1:1").osis()).toEqual("1Cor.1.1", "parsing: '1COR 1:1'")
 		;
       return true;
     });
@@ -1958,11 +2246,11 @@
     });
     return it("should handle book: Gal (de)", function() {
       
-		expect(p.parse("Galater 1:1").osis()).toEqual("Gal.1.1")
-		expect(p.parse("Gal 1:1").osis()).toEqual("Gal.1.1")
+		expect(p.parse("Galater 1:1").osis()).toEqual("Gal.1.1", "parsing: 'Galater 1:1'")
+		expect(p.parse("Gal 1:1").osis()).toEqual("Gal.1.1", "parsing: 'Gal 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("GALATER 1:1").osis()).toEqual("Gal.1.1")
-		expect(p.parse("GAL 1:1").osis()).toEqual("Gal.1.1")
+		expect(p.parse("GALATER 1:1").osis()).toEqual("Gal.1.1", "parsing: 'GALATER 1:1'")
+		expect(p.parse("GAL 1:1").osis()).toEqual("Gal.1.1", "parsing: 'GAL 1:1'")
 		;
       return true;
     });
@@ -1983,11 +2271,11 @@
     });
     return it("should handle book: Eph (de)", function() {
       
-		expect(p.parse("Epheser 1:1").osis()).toEqual("Eph.1.1")
-		expect(p.parse("Eph 1:1").osis()).toEqual("Eph.1.1")
+		expect(p.parse("Epheser 1:1").osis()).toEqual("Eph.1.1", "parsing: 'Epheser 1:1'")
+		expect(p.parse("Eph 1:1").osis()).toEqual("Eph.1.1", "parsing: 'Eph 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("EPHESER 1:1").osis()).toEqual("Eph.1.1")
-		expect(p.parse("EPH 1:1").osis()).toEqual("Eph.1.1")
+		expect(p.parse("EPHESER 1:1").osis()).toEqual("Eph.1.1", "parsing: 'EPHESER 1:1'")
+		expect(p.parse("EPH 1:1").osis()).toEqual("Eph.1.1", "parsing: 'EPH 1:1'")
 		;
       return true;
     });
@@ -2008,11 +2296,11 @@
     });
     return it("should handle book: Phil (de)", function() {
       
-		expect(p.parse("Philipper 1:1").osis()).toEqual("Phil.1.1")
-		expect(p.parse("Phil 1:1").osis()).toEqual("Phil.1.1")
+		expect(p.parse("Philipper 1:1").osis()).toEqual("Phil.1.1", "parsing: 'Philipper 1:1'")
+		expect(p.parse("Phil 1:1").osis()).toEqual("Phil.1.1", "parsing: 'Phil 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("PHILIPPER 1:1").osis()).toEqual("Phil.1.1")
-		expect(p.parse("PHIL 1:1").osis()).toEqual("Phil.1.1")
+		expect(p.parse("PHILIPPER 1:1").osis()).toEqual("Phil.1.1", "parsing: 'PHILIPPER 1:1'")
+		expect(p.parse("PHIL 1:1").osis()).toEqual("Phil.1.1", "parsing: 'PHIL 1:1'")
 		;
       return true;
     });
@@ -2033,13 +2321,13 @@
     });
     return it("should handle book: Col (de)", function() {
       
-		expect(p.parse("Kolosser 1:1").osis()).toEqual("Col.1.1")
-		expect(p.parse("Col 1:1").osis()).toEqual("Col.1.1")
-		expect(p.parse("Kol 1:1").osis()).toEqual("Col.1.1")
+		expect(p.parse("Kolosser 1:1").osis()).toEqual("Col.1.1", "parsing: 'Kolosser 1:1'")
+		expect(p.parse("Col 1:1").osis()).toEqual("Col.1.1", "parsing: 'Col 1:1'")
+		expect(p.parse("Kol 1:1").osis()).toEqual("Col.1.1", "parsing: 'Kol 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("KOLOSSER 1:1").osis()).toEqual("Col.1.1")
-		expect(p.parse("COL 1:1").osis()).toEqual("Col.1.1")
-		expect(p.parse("KOL 1:1").osis()).toEqual("Col.1.1")
+		expect(p.parse("KOLOSSER 1:1").osis()).toEqual("Col.1.1", "parsing: 'KOLOSSER 1:1'")
+		expect(p.parse("COL 1:1").osis()).toEqual("Col.1.1", "parsing: 'COL 1:1'")
+		expect(p.parse("KOL 1:1").osis()).toEqual("Col.1.1", "parsing: 'KOL 1:1'")
 		;
       return true;
     });
@@ -2060,19 +2348,29 @@
     });
     return it("should handle book: 2Thess (de)", function() {
       
-		expect(p.parse("Zweite Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2. Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2 Thessalonicher 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2. Thess 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2 Thess 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2Thess 1:1").osis()).toEqual("2Thess.1.1")
+		expect(p.parse("Zweiten Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'Zweiten Thessalonicher 1:1'")
+		expect(p.parse("Zweiter Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'Zweiter Thessalonicher 1:1'")
+		expect(p.parse("Zweites Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'Zweites Thessalonicher 1:1'")
+		expect(p.parse("Zweite Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'Zweite Thessalonicher 1:1'")
+		expect(p.parse("2. Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. Thessalonicher 1:1'")
+		expect(p.parse("2 Thessalonicher 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 Thessalonicher 1:1'")
+		expect(p.parse("2. Thess 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. Thess 1:1'")
+		expect(p.parse("2 Thess 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 Thess 1:1'")
+		expect(p.parse("2Thess 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2Thess 1:1'")
+		expect(p.parse("2. Th 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. Th 1:1'")
+		expect(p.parse("2 Th 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 Th 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITE THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2. THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2 THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2. THESS 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2 THESS 1:1").osis()).toEqual("2Thess.1.1")
-		expect(p.parse("2THESS 1:1").osis()).toEqual("2Thess.1.1")
+		expect(p.parse("ZWEITEN THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'ZWEITEN THESSALONICHER 1:1'")
+		expect(p.parse("ZWEITER THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'ZWEITER THESSALONICHER 1:1'")
+		expect(p.parse("ZWEITES THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'ZWEITES THESSALONICHER 1:1'")
+		expect(p.parse("ZWEITE THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: 'ZWEITE THESSALONICHER 1:1'")
+		expect(p.parse("2. THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. THESSALONICHER 1:1'")
+		expect(p.parse("2 THESSALONICHER 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 THESSALONICHER 1:1'")
+		expect(p.parse("2. THESS 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. THESS 1:1'")
+		expect(p.parse("2 THESS 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 THESS 1:1'")
+		expect(p.parse("2THESS 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2THESS 1:1'")
+		expect(p.parse("2. TH 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2. TH 1:1'")
+		expect(p.parse("2 TH 1:1").osis()).toEqual("2Thess.1.1", "parsing: '2 TH 1:1'")
 		;
       return true;
     });
@@ -2093,19 +2391,29 @@
     });
     return it("should handle book: 1Thess (de)", function() {
       
-		expect(p.parse("Erste Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1. Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1 Thessalonicher 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1. Thess 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1 Thess 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1Thess 1:1").osis()).toEqual("1Thess.1.1")
+		expect(p.parse("Ersten Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'Ersten Thessalonicher 1:1'")
+		expect(p.parse("Erster Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'Erster Thessalonicher 1:1'")
+		expect(p.parse("Erstes Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'Erstes Thessalonicher 1:1'")
+		expect(p.parse("Erste Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'Erste Thessalonicher 1:1'")
+		expect(p.parse("1. Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. Thessalonicher 1:1'")
+		expect(p.parse("1 Thessalonicher 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 Thessalonicher 1:1'")
+		expect(p.parse("1. Thess 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. Thess 1:1'")
+		expect(p.parse("1 Thess 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 Thess 1:1'")
+		expect(p.parse("1Thess 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1Thess 1:1'")
+		expect(p.parse("1. Th 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. Th 1:1'")
+		expect(p.parse("1 Th 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 Th 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTE THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1. THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1 THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1. THESS 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1 THESS 1:1").osis()).toEqual("1Thess.1.1")
-		expect(p.parse("1THESS 1:1").osis()).toEqual("1Thess.1.1")
+		expect(p.parse("ERSTEN THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'ERSTEN THESSALONICHER 1:1'")
+		expect(p.parse("ERSTER THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'ERSTER THESSALONICHER 1:1'")
+		expect(p.parse("ERSTES THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'ERSTES THESSALONICHER 1:1'")
+		expect(p.parse("ERSTE THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: 'ERSTE THESSALONICHER 1:1'")
+		expect(p.parse("1. THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. THESSALONICHER 1:1'")
+		expect(p.parse("1 THESSALONICHER 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 THESSALONICHER 1:1'")
+		expect(p.parse("1. THESS 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. THESS 1:1'")
+		expect(p.parse("1 THESS 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 THESS 1:1'")
+		expect(p.parse("1THESS 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1THESS 1:1'")
+		expect(p.parse("1. TH 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1. TH 1:1'")
+		expect(p.parse("1 TH 1:1").osis()).toEqual("1Thess.1.1", "parsing: '1 TH 1:1'")
 		;
       return true;
     });
@@ -2126,19 +2434,25 @@
     });
     return it("should handle book: 2Tim (de)", function() {
       
-		expect(p.parse("Zweite Timotheus 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2. Timotheus 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2 Timotheus 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2. Tim 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2 Tim 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2Tim 1:1").osis()).toEqual("2Tim.1.1")
+		expect(p.parse("Zweiten Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'Zweiten Timotheus 1:1'")
+		expect(p.parse("Zweiter Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'Zweiter Timotheus 1:1'")
+		expect(p.parse("Zweites Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'Zweites Timotheus 1:1'")
+		expect(p.parse("Zweite Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'Zweite Timotheus 1:1'")
+		expect(p.parse("2. Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2. Timotheus 1:1'")
+		expect(p.parse("2 Timotheus 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2 Timotheus 1:1'")
+		expect(p.parse("2. Tim 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2. Tim 1:1'")
+		expect(p.parse("2 Tim 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2 Tim 1:1'")
+		expect(p.parse("2Tim 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2Tim 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITE TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2. TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2 TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2. TIM 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2 TIM 1:1").osis()).toEqual("2Tim.1.1")
-		expect(p.parse("2TIM 1:1").osis()).toEqual("2Tim.1.1")
+		expect(p.parse("ZWEITEN TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'ZWEITEN TIMOTHEUS 1:1'")
+		expect(p.parse("ZWEITER TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'ZWEITER TIMOTHEUS 1:1'")
+		expect(p.parse("ZWEITES TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'ZWEITES TIMOTHEUS 1:1'")
+		expect(p.parse("ZWEITE TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: 'ZWEITE TIMOTHEUS 1:1'")
+		expect(p.parse("2. TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2. TIMOTHEUS 1:1'")
+		expect(p.parse("2 TIMOTHEUS 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2 TIMOTHEUS 1:1'")
+		expect(p.parse("2. TIM 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2. TIM 1:1'")
+		expect(p.parse("2 TIM 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2 TIM 1:1'")
+		expect(p.parse("2TIM 1:1").osis()).toEqual("2Tim.1.1", "parsing: '2TIM 1:1'")
 		;
       return true;
     });
@@ -2159,19 +2473,25 @@
     });
     return it("should handle book: 1Tim (de)", function() {
       
-		expect(p.parse("Erste Timotheus 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1. Timotheus 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1 Timotheus 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1. Tim 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1 Tim 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1Tim 1:1").osis()).toEqual("1Tim.1.1")
+		expect(p.parse("Ersten Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'Ersten Timotheus 1:1'")
+		expect(p.parse("Erster Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'Erster Timotheus 1:1'")
+		expect(p.parse("Erstes Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'Erstes Timotheus 1:1'")
+		expect(p.parse("Erste Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'Erste Timotheus 1:1'")
+		expect(p.parse("1. Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1. Timotheus 1:1'")
+		expect(p.parse("1 Timotheus 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1 Timotheus 1:1'")
+		expect(p.parse("1. Tim 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1. Tim 1:1'")
+		expect(p.parse("1 Tim 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1 Tim 1:1'")
+		expect(p.parse("1Tim 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1Tim 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTE TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1. TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1 TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1. TIM 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1 TIM 1:1").osis()).toEqual("1Tim.1.1")
-		expect(p.parse("1TIM 1:1").osis()).toEqual("1Tim.1.1")
+		expect(p.parse("ERSTEN TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'ERSTEN TIMOTHEUS 1:1'")
+		expect(p.parse("ERSTER TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'ERSTER TIMOTHEUS 1:1'")
+		expect(p.parse("ERSTES TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'ERSTES TIMOTHEUS 1:1'")
+		expect(p.parse("ERSTE TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: 'ERSTE TIMOTHEUS 1:1'")
+		expect(p.parse("1. TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1. TIMOTHEUS 1:1'")
+		expect(p.parse("1 TIMOTHEUS 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1 TIMOTHEUS 1:1'")
+		expect(p.parse("1. TIM 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1. TIM 1:1'")
+		expect(p.parse("1 TIM 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1 TIM 1:1'")
+		expect(p.parse("1TIM 1:1").osis()).toEqual("1Tim.1.1", "parsing: '1TIM 1:1'")
 		;
       return true;
     });
@@ -2192,11 +2512,11 @@
     });
     return it("should handle book: Titus (de)", function() {
       
-		expect(p.parse("Titus 1:1").osis()).toEqual("Titus.1.1")
-		expect(p.parse("Tit 1:1").osis()).toEqual("Titus.1.1")
+		expect(p.parse("Titus 1:1").osis()).toEqual("Titus.1.1", "parsing: 'Titus 1:1'")
+		expect(p.parse("Tit 1:1").osis()).toEqual("Titus.1.1", "parsing: 'Tit 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("TITUS 1:1").osis()).toEqual("Titus.1.1")
-		expect(p.parse("TIT 1:1").osis()).toEqual("Titus.1.1")
+		expect(p.parse("TITUS 1:1").osis()).toEqual("Titus.1.1", "parsing: 'TITUS 1:1'")
+		expect(p.parse("TIT 1:1").osis()).toEqual("Titus.1.1", "parsing: 'TIT 1:1'")
 		;
       return true;
     });
@@ -2217,13 +2537,13 @@
     });
     return it("should handle book: Phlm (de)", function() {
       
-		expect(p.parse("Philemon 1:1").osis()).toEqual("Phlm.1.1")
-		expect(p.parse("Phlm 1:1").osis()).toEqual("Phlm.1.1")
-		expect(p.parse("Phm 1:1").osis()).toEqual("Phlm.1.1")
+		expect(p.parse("Philemon 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'Philemon 1:1'")
+		expect(p.parse("Phlm 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'Phlm 1:1'")
+		expect(p.parse("Phm 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'Phm 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("PHILEMON 1:1").osis()).toEqual("Phlm.1.1")
-		expect(p.parse("PHLM 1:1").osis()).toEqual("Phlm.1.1")
-		expect(p.parse("PHM 1:1").osis()).toEqual("Phlm.1.1")
+		expect(p.parse("PHILEMON 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'PHILEMON 1:1'")
+		expect(p.parse("PHLM 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'PHLM 1:1'")
+		expect(p.parse("PHM 1:1").osis()).toEqual("Phlm.1.1", "parsing: 'PHM 1:1'")
 		;
       return true;
     });
@@ -2244,17 +2564,19 @@
     });
     return it("should handle book: Heb (de)", function() {
       
-		expect(p.parse("Hebraeer 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("Hebraer 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("Hebräer 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("Hebr 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("Heb 1:1").osis()).toEqual("Heb.1.1")
+		expect(p.parse("Hebraeer 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hebraeer 1:1'")
+		expect(p.parse("Hebraer 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hebraer 1:1'")
+		expect(p.parse("Hebräer 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hebräer 1:1'")
+		expect(p.parse("Hebr 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hebr 1:1'")
+		expect(p.parse("Heb 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Heb 1:1'")
+		expect(p.parse("Hb 1:1").osis()).toEqual("Heb.1.1", "parsing: 'Hb 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("HEBRAEER 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("HEBRAER 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("HEBRÄER 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("HEBR 1:1").osis()).toEqual("Heb.1.1")
-		expect(p.parse("HEB 1:1").osis()).toEqual("Heb.1.1")
+		expect(p.parse("HEBRAEER 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEBRAEER 1:1'")
+		expect(p.parse("HEBRAER 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEBRAER 1:1'")
+		expect(p.parse("HEBRÄER 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEBRÄER 1:1'")
+		expect(p.parse("HEBR 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEBR 1:1'")
+		expect(p.parse("HEB 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HEB 1:1'")
+		expect(p.parse("HB 1:1").osis()).toEqual("Heb.1.1", "parsing: 'HB 1:1'")
 		;
       return true;
     });
@@ -2275,15 +2597,17 @@
     });
     return it("should handle book: Jas (de)", function() {
       
-		expect(p.parse("Jakobusbrief 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("Jakobus 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("Jak 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("Jas 1:1").osis()).toEqual("Jas.1.1")
+		expect(p.parse("Jakobusbrief 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jakobusbrief 1:1'")
+		expect(p.parse("Jakobus 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jakobus 1:1'")
+		expect(p.parse("Jak 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jak 1:1'")
+		expect(p.parse("Jas 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jas 1:1'")
+		expect(p.parse("Jk 1:1").osis()).toEqual("Jas.1.1", "parsing: 'Jk 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JAKOBUSBRIEF 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("JAKOBUS 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("JAK 1:1").osis()).toEqual("Jas.1.1")
-		expect(p.parse("JAS 1:1").osis()).toEqual("Jas.1.1")
+		expect(p.parse("JAKOBUSBRIEF 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JAKOBUSBRIEF 1:1'")
+		expect(p.parse("JAKOBUS 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JAKOBUS 1:1'")
+		expect(p.parse("JAK 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JAK 1:1'")
+		expect(p.parse("JAS 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JAS 1:1'")
+		expect(p.parse("JK 1:1").osis()).toEqual("Jas.1.1", "parsing: 'JK 1:1'")
 		;
       return true;
     });
@@ -2304,19 +2628,33 @@
     });
     return it("should handle book: 2Pet (de)", function() {
       
-		expect(p.parse("Zweite Petrus 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2. Petrus 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2 Petrus 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2. Petr 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2 Petr 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2Pet 1:1").osis()).toEqual("2Pet.1.1")
+		expect(p.parse("Zweiten Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'Zweiten Petrus 1:1'")
+		expect(p.parse("Zweiter Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'Zweiter Petrus 1:1'")
+		expect(p.parse("Zweites Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'Zweites Petrus 1:1'")
+		expect(p.parse("Zweite Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'Zweite Petrus 1:1'")
+		expect(p.parse("2. Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. Petrus 1:1'")
+		expect(p.parse("2 Petrus 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 Petrus 1:1'")
+		expect(p.parse("2. Petr 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. Petr 1:1'")
+		expect(p.parse("2 Petr 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 Petr 1:1'")
+		expect(p.parse("2. Pet 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. Pet 1:1'")
+		expect(p.parse("2 Pet 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 Pet 1:1'")
+		expect(p.parse("2. Pt 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. Pt 1:1'")
+		expect(p.parse("2 Pt 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 Pt 1:1'")
+		expect(p.parse("2Pet 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2Pet 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ZWEITE PETRUS 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2. PETRUS 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2 PETRUS 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2. PETR 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2 PETR 1:1").osis()).toEqual("2Pet.1.1")
-		expect(p.parse("2PET 1:1").osis()).toEqual("2Pet.1.1")
+		expect(p.parse("ZWEITEN PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'ZWEITEN PETRUS 1:1'")
+		expect(p.parse("ZWEITER PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'ZWEITER PETRUS 1:1'")
+		expect(p.parse("ZWEITES PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'ZWEITES PETRUS 1:1'")
+		expect(p.parse("ZWEITE PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: 'ZWEITE PETRUS 1:1'")
+		expect(p.parse("2. PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. PETRUS 1:1'")
+		expect(p.parse("2 PETRUS 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 PETRUS 1:1'")
+		expect(p.parse("2. PETR 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. PETR 1:1'")
+		expect(p.parse("2 PETR 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 PETR 1:1'")
+		expect(p.parse("2. PET 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. PET 1:1'")
+		expect(p.parse("2 PET 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 PET 1:1'")
+		expect(p.parse("2. PT 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2. PT 1:1'")
+		expect(p.parse("2 PT 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2 PT 1:1'")
+		expect(p.parse("2PET 1:1").osis()).toEqual("2Pet.1.1", "parsing: '2PET 1:1'")
 		;
       return true;
     });
@@ -2337,19 +2675,33 @@
     });
     return it("should handle book: 1Pet (de)", function() {
       
-		expect(p.parse("Erste Petrus 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1. Petrus 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1 Petrus 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1. Petr 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1 Petr 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1Pet 1:1").osis()).toEqual("1Pet.1.1")
+		expect(p.parse("Ersten Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'Ersten Petrus 1:1'")
+		expect(p.parse("Erster Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'Erster Petrus 1:1'")
+		expect(p.parse("Erstes Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'Erstes Petrus 1:1'")
+		expect(p.parse("Erste Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'Erste Petrus 1:1'")
+		expect(p.parse("1. Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. Petrus 1:1'")
+		expect(p.parse("1 Petrus 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 Petrus 1:1'")
+		expect(p.parse("1. Petr 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. Petr 1:1'")
+		expect(p.parse("1 Petr 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 Petr 1:1'")
+		expect(p.parse("1. Pet 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. Pet 1:1'")
+		expect(p.parse("1 Pet 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 Pet 1:1'")
+		expect(p.parse("1. Pt 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. Pt 1:1'")
+		expect(p.parse("1 Pt 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 Pt 1:1'")
+		expect(p.parse("1Pet 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1Pet 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("ERSTE PETRUS 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1. PETRUS 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1 PETRUS 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1. PETR 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1 PETR 1:1").osis()).toEqual("1Pet.1.1")
-		expect(p.parse("1PET 1:1").osis()).toEqual("1Pet.1.1")
+		expect(p.parse("ERSTEN PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'ERSTEN PETRUS 1:1'")
+		expect(p.parse("ERSTER PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'ERSTER PETRUS 1:1'")
+		expect(p.parse("ERSTES PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'ERSTES PETRUS 1:1'")
+		expect(p.parse("ERSTE PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: 'ERSTE PETRUS 1:1'")
+		expect(p.parse("1. PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. PETRUS 1:1'")
+		expect(p.parse("1 PETRUS 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 PETRUS 1:1'")
+		expect(p.parse("1. PETR 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. PETR 1:1'")
+		expect(p.parse("1 PETR 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 PETR 1:1'")
+		expect(p.parse("1. PET 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. PET 1:1'")
+		expect(p.parse("1 PET 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 PET 1:1'")
+		expect(p.parse("1. PT 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1. PT 1:1'")
+		expect(p.parse("1 PT 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1 PT 1:1'")
+		expect(p.parse("1PET 1:1").osis()).toEqual("1Pet.1.1", "parsing: '1PET 1:1'")
 		;
       return true;
     });
@@ -2370,13 +2722,13 @@
     });
     return it("should handle book: Jude (de)", function() {
       
-		expect(p.parse("Judas 1:1").osis()).toEqual("Jude.1.1")
-		expect(p.parse("Jude 1:1").osis()).toEqual("Jude.1.1")
-		expect(p.parse("Jud 1:1").osis()).toEqual("Jude.1.1")
+		expect(p.parse("Judas 1:1").osis()).toEqual("Jude.1.1", "parsing: 'Judas 1:1'")
+		expect(p.parse("Jude 1:1").osis()).toEqual("Jude.1.1", "parsing: 'Jude 1:1'")
+		expect(p.parse("Jud 1:1").osis()).toEqual("Jude.1.1", "parsing: 'Jud 1:1'")
 		p.include_apocrypha(false)
-		expect(p.parse("JUDAS 1:1").osis()).toEqual("Jude.1.1")
-		expect(p.parse("JUDE 1:1").osis()).toEqual("Jude.1.1")
-		expect(p.parse("JUD 1:1").osis()).toEqual("Jude.1.1")
+		expect(p.parse("JUDAS 1:1").osis()).toEqual("Jude.1.1", "parsing: 'JUDAS 1:1'")
+		expect(p.parse("JUDE 1:1").osis()).toEqual("Jude.1.1", "parsing: 'JUDE 1:1'")
+		expect(p.parse("JUD 1:1").osis()).toEqual("Jude.1.1", "parsing: 'JUD 1:1'")
 		;
       return true;
     });
@@ -2397,9 +2749,9 @@
     });
     return it("should handle book: Tob (de)", function() {
       
-		expect(p.parse("Tobias 1:1").osis()).toEqual("Tob.1.1")
-		expect(p.parse("Tobit 1:1").osis()).toEqual("Tob.1.1")
-		expect(p.parse("Tob 1:1").osis()).toEqual("Tob.1.1")
+		expect(p.parse("Tobias 1:1").osis()).toEqual("Tob.1.1", "parsing: 'Tobias 1:1'")
+		expect(p.parse("Tobit 1:1").osis()).toEqual("Tob.1.1", "parsing: 'Tobit 1:1'")
+		expect(p.parse("Tob 1:1").osis()).toEqual("Tob.1.1", "parsing: 'Tob 1:1'")
 		;
       return true;
     });
@@ -2420,8 +2772,8 @@
     });
     return it("should handle book: Jdt (de)", function() {
       
-		expect(p.parse("Judit 1:1").osis()).toEqual("Jdt.1.1")
-		expect(p.parse("Jdt 1:1").osis()).toEqual("Jdt.1.1")
+		expect(p.parse("Judit 1:1").osis()).toEqual("Jdt.1.1", "parsing: 'Judit 1:1'")
+		expect(p.parse("Jdt 1:1").osis()).toEqual("Jdt.1.1", "parsing: 'Jdt 1:1'")
 		;
       return true;
     });
@@ -2442,8 +2794,8 @@
     });
     return it("should handle book: Bar (de)", function() {
       
-		expect(p.parse("Baruch 1:1").osis()).toEqual("Bar.1.1")
-		expect(p.parse("Bar 1:1").osis()).toEqual("Bar.1.1")
+		expect(p.parse("Baruch 1:1").osis()).toEqual("Bar.1.1", "parsing: 'Baruch 1:1'")
+		expect(p.parse("Bar 1:1").osis()).toEqual("Bar.1.1", "parsing: 'Bar 1:1'")
 		;
       return true;
     });
@@ -2464,10 +2816,8 @@
     });
     return it("should handle book: Sus (de)", function() {
       
-		expect(p.parse("Susanna und die Alten 1:1").osis()).toEqual("Sus.1.1")
-		expect(p.parse("Susanna im Bade 1:1").osis()).toEqual("Sus.1.1")
-		expect(p.parse("Susanna 1:1").osis()).toEqual("Sus.1.1")
-		expect(p.parse("Sus 1:1").osis()).toEqual("Sus.1.1")
+		expect(p.parse("Susanna 1:1").osis()).toEqual("Sus.1.1", "parsing: 'Susanna 1:1'")
+		expect(p.parse("Sus 1:1").osis()).toEqual("Sus.1.1", "parsing: 'Sus 1:1'")
 		;
       return true;
     });
@@ -2488,15 +2838,27 @@
     });
     return it("should handle book: 2Macc (de)", function() {
       
-		expect(p.parse("Zweite Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("Zweite Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2. Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2. Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2 Makkabaer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2 Makkabäer 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2. Makk 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2 Makk 1:1").osis()).toEqual("2Macc.1.1")
-		expect(p.parse("2Macc 1:1").osis()).toEqual("2Macc.1.1")
+		expect(p.parse("Zweiten Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiten Makkabaeer 1:1'")
+		expect(p.parse("Zweiter Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiter Makkabaeer 1:1'")
+		expect(p.parse("Zweites Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweites Makkabaeer 1:1'")
+		expect(p.parse("Zweite Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweite Makkabaeer 1:1'")
+		expect(p.parse("Zweiten Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiten Makkabaer 1:1'")
+		expect(p.parse("Zweiten Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiten Makkabäer 1:1'")
+		expect(p.parse("Zweiter Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiter Makkabaer 1:1'")
+		expect(p.parse("Zweiter Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweiter Makkabäer 1:1'")
+		expect(p.parse("Zweites Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweites Makkabaer 1:1'")
+		expect(p.parse("Zweites Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweites Makkabäer 1:1'")
+		expect(p.parse("Zweite Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweite Makkabaer 1:1'")
+		expect(p.parse("Zweite Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: 'Zweite Makkabäer 1:1'")
+		expect(p.parse("2. Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2. Makkabaeer 1:1'")
+		expect(p.parse("2 Makkabaeer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2 Makkabaeer 1:1'")
+		expect(p.parse("2. Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2. Makkabaer 1:1'")
+		expect(p.parse("2. Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2. Makkabäer 1:1'")
+		expect(p.parse("2 Makkabaer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2 Makkabaer 1:1'")
+		expect(p.parse("2 Makkabäer 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2 Makkabäer 1:1'")
+		expect(p.parse("2. Makk 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2. Makk 1:1'")
+		expect(p.parse("2 Makk 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2 Makk 1:1'")
+		expect(p.parse("2Macc 1:1").osis()).toEqual("2Macc.1.1", "parsing: '2Macc 1:1'")
 		;
       return true;
     });
@@ -2517,15 +2879,27 @@
     });
     return it("should handle book: 3Macc (de)", function() {
       
-		expect(p.parse("Dritte Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("Dritte Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3. Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3. Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3 Makkabaer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3 Makkabäer 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3. Makk 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3 Makk 1:1").osis()).toEqual("3Macc.1.1")
-		expect(p.parse("3Macc 1:1").osis()).toEqual("3Macc.1.1")
+		expect(p.parse("Dritten Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritten Makkabaeer 1:1'")
+		expect(p.parse("Dritter Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritter Makkabaeer 1:1'")
+		expect(p.parse("Drittes Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Drittes Makkabaeer 1:1'")
+		expect(p.parse("Dritte Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritte Makkabaeer 1:1'")
+		expect(p.parse("Dritten Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritten Makkabaer 1:1'")
+		expect(p.parse("Dritten Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritten Makkabäer 1:1'")
+		expect(p.parse("Dritter Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritter Makkabaer 1:1'")
+		expect(p.parse("Dritter Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritter Makkabäer 1:1'")
+		expect(p.parse("Drittes Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Drittes Makkabaer 1:1'")
+		expect(p.parse("Drittes Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Drittes Makkabäer 1:1'")
+		expect(p.parse("Dritte Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritte Makkabaer 1:1'")
+		expect(p.parse("Dritte Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: 'Dritte Makkabäer 1:1'")
+		expect(p.parse("3. Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3. Makkabaeer 1:1'")
+		expect(p.parse("3 Makkabaeer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3 Makkabaeer 1:1'")
+		expect(p.parse("3. Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3. Makkabaer 1:1'")
+		expect(p.parse("3. Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3. Makkabäer 1:1'")
+		expect(p.parse("3 Makkabaer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3 Makkabaer 1:1'")
+		expect(p.parse("3 Makkabäer 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3 Makkabäer 1:1'")
+		expect(p.parse("3. Makk 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3. Makk 1:1'")
+		expect(p.parse("3 Makk 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3 Makk 1:1'")
+		expect(p.parse("3Macc 1:1").osis()).toEqual("3Macc.1.1", "parsing: '3Macc 1:1'")
 		;
       return true;
     });
@@ -2546,15 +2920,24 @@
     });
     return it("should handle book: 4Macc (de)", function() {
       
-		expect(p.parse("Vierte Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("Vierte Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4. Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4. Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4 Makkabaer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4 Makkabäer 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4. Makk 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4 Makk 1:1").osis()).toEqual("4Macc.1.1")
-		expect(p.parse("4Macc 1:1").osis()).toEqual("4Macc.1.1")
+		expect(p.parse("Vierten Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierten Makkabaeer 1:1'")
+		expect(p.parse("Viertes Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Viertes Makkabaeer 1:1'")
+		expect(p.parse("Vierte Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierte Makkabaeer 1:1'")
+		expect(p.parse("Vierten Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierten Makkabaer 1:1'")
+		expect(p.parse("Vierten Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierten Makkabäer 1:1'")
+		expect(p.parse("Viertes Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Viertes Makkabaer 1:1'")
+		expect(p.parse("Viertes Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Viertes Makkabäer 1:1'")
+		expect(p.parse("Vierte Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierte Makkabaer 1:1'")
+		expect(p.parse("Vierte Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: 'Vierte Makkabäer 1:1'")
+		expect(p.parse("4. Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4. Makkabaeer 1:1'")
+		expect(p.parse("4 Makkabaeer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4 Makkabaeer 1:1'")
+		expect(p.parse("4. Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4. Makkabaer 1:1'")
+		expect(p.parse("4. Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4. Makkabäer 1:1'")
+		expect(p.parse("4 Makkabaer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4 Makkabaer 1:1'")
+		expect(p.parse("4 Makkabäer 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4 Makkabäer 1:1'")
+		expect(p.parse("4. Makk 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4. Makk 1:1'")
+		expect(p.parse("4 Makk 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4 Makk 1:1'")
+		expect(p.parse("4Macc 1:1").osis()).toEqual("4Macc.1.1", "parsing: '4Macc 1:1'")
 		;
       return true;
     });
@@ -2575,61 +2958,27 @@
     });
     return it("should handle book: 1Macc (de)", function() {
       
-		expect(p.parse("Erste Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("Erste Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1. Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1. Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1 Makkabaer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1 Makkabäer 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1. Makk 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1 Makk 1:1").osis()).toEqual("1Macc.1.1")
-		expect(p.parse("1Macc 1:1").osis()).toEqual("1Macc.1.1")
-		;
-      return true;
-    });
-  });
-
-  describe("Localized book Ezra,Esth (de)", function() {
-    var p;
-    p = {};
-    beforeEach(function() {
-      p = new bcv_parser;
-      p.set_options({
-        book_alone_strategy: "ignore",
-        book_sequence_strategy: "ignore",
-        osis_compaction_strategy: "bc",
-        captive_end_digits_strategy: "delete"
-      });
-      return p.include_apocrypha(true);
-    });
-    return it("should handle book: Ezra,Esth (de)", function() {
-      
-		expect(p.parse("Es 1:1").osis()).toEqual("Ezra.1.1")
-		p.include_apocrypha(false)
-		expect(p.parse("ES 1:1").osis()).toEqual("Ezra.1.1")
-		;
-      return true;
-    });
-  });
-
-  describe("Localized book Phil,Phlm (de)", function() {
-    var p;
-    p = {};
-    beforeEach(function() {
-      p = new bcv_parser;
-      p.set_options({
-        book_alone_strategy: "ignore",
-        book_sequence_strategy: "ignore",
-        osis_compaction_strategy: "bc",
-        captive_end_digits_strategy: "delete"
-      });
-      return p.include_apocrypha(true);
-    });
-    return it("should handle book: Phil,Phlm (de)", function() {
-      
-		expect(p.parse("Ph 1:1").osis()).toEqual("Phil.1.1")
-		p.include_apocrypha(false)
-		expect(p.parse("PH 1:1").osis()).toEqual("Phil.1.1")
+		expect(p.parse("Ersten Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Ersten Makkabaeer 1:1'")
+		expect(p.parse("Erster Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erster Makkabaeer 1:1'")
+		expect(p.parse("Erstes Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erstes Makkabaeer 1:1'")
+		expect(p.parse("Erste Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erste Makkabaeer 1:1'")
+		expect(p.parse("Ersten Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Ersten Makkabaer 1:1'")
+		expect(p.parse("Ersten Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Ersten Makkabäer 1:1'")
+		expect(p.parse("Erster Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erster Makkabaer 1:1'")
+		expect(p.parse("Erster Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erster Makkabäer 1:1'")
+		expect(p.parse("Erstes Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erstes Makkabaer 1:1'")
+		expect(p.parse("Erstes Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erstes Makkabäer 1:1'")
+		expect(p.parse("Erste Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erste Makkabaer 1:1'")
+		expect(p.parse("Erste Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: 'Erste Makkabäer 1:1'")
+		expect(p.parse("1. Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1. Makkabaeer 1:1'")
+		expect(p.parse("1 Makkabaeer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1 Makkabaeer 1:1'")
+		expect(p.parse("1. Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1. Makkabaer 1:1'")
+		expect(p.parse("1. Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1. Makkabäer 1:1'")
+		expect(p.parse("1 Makkabaer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1 Makkabaer 1:1'")
+		expect(p.parse("1 Makkabäer 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1 Makkabäer 1:1'")
+		expect(p.parse("1. Makk 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1. Makk 1:1'")
+		expect(p.parse("1 Makk 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1 Makk 1:1'")
+		expect(p.parse("1Macc 1:1").osis()).toEqual("1Macc.1.1", "parsing: '1Macc 1:1'")
 		;
       return true;
     });
@@ -2652,49 +3001,73 @@
       return expect(p.languages).toEqual(["de"]);
     });
     it("should handle ranges (de)", function() {
-      expect(p.parse("Titus 1:1 bis 2").osis()).toEqual("Titus.1.1-Titus.1.2");
-      expect(p.parse("Matt 1bis2").osis()).toEqual("Matt.1-Matt.2");
-      return expect(p.parse("Phlm 2 BIS 3").osis()).toEqual("Phlm.1.2-Phlm.1.3");
+      expect(p.parse("Titus 1:1 bis 2").osis()).toEqual("Titus.1.1-Titus.1.2", "parsing: 'Titus 1:1 bis 2'");
+      expect(p.parse("Matt 1bis2").osis()).toEqual("Matt.1-Matt.2", "parsing: 'Matt 1bis2'");
+      return expect(p.parse("Phlm 2 BIS 3").osis()).toEqual("Phlm.1.2-Phlm.1.3", "parsing: 'Phlm 2 BIS 3'");
     });
     it("should handle chapters (de)", function() {
-      expect(p.parse("Titus 1:1, Kapitel 2").osis()).toEqual("Titus.1.1,Titus.2");
-      expect(p.parse("Matt 3:4 KAPITEL 6").osis()).toEqual("Matt.3.4,Matt.6");
-      expect(p.parse("Titus 1:1, Kap. 2").osis()).toEqual("Titus.1.1,Titus.2");
-      expect(p.parse("Matt 3:4 KAP. 6").osis()).toEqual("Matt.3.4,Matt.6");
-      expect(p.parse("Titus 1:1, Kap 2").osis()).toEqual("Titus.1.1,Titus.2");
-      return expect(p.parse("Matt 3:4 KAP 6").osis()).toEqual("Matt.3.4,Matt.6");
+      expect(p.parse("Titus 1:1, Kapiteln 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kapiteln 2'");
+      expect(p.parse("Matt 3:4 KAPITELN 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAPITELN 6'");
+      expect(p.parse("Titus 1:1, Kapiteln 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kapiteln 2'");
+      expect(p.parse("Matt 3:4 KAPITELN 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAPITELN 6'");
+      expect(p.parse("Titus 1:1, Kapitel 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kapitel 2'");
+      expect(p.parse("Matt 3:4 KAPITEL 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAPITEL 6'");
+      expect(p.parse("Titus 1:1, Kap. 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kap. 2'");
+      expect(p.parse("Matt 3:4 KAP. 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAP. 6'");
+      expect(p.parse("Titus 1:1, Kap 2").osis()).toEqual("Titus.1.1,Titus.2", "parsing: 'Titus 1:1, Kap 2'");
+      return expect(p.parse("Matt 3:4 KAP 6").osis()).toEqual("Matt.3.4,Matt.6", "parsing: 'Matt 3:4 KAP 6'");
     });
     it("should handle verses (de)", function() {
-      expect(p.parse("Exod 1:1 Verse 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      expect(p.parse("Phlm VERSE 6").osis()).toEqual("Phlm.1.6");
-      expect(p.parse("Exod 1:1 Vers. 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      expect(p.parse("Phlm VERS. 6").osis()).toEqual("Phlm.1.6");
-      expect(p.parse("Exod 1:1 Vers 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      expect(p.parse("Phlm VERS 6").osis()).toEqual("Phlm.1.6");
-      expect(p.parse("Exod 1:1 Ver. 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      expect(p.parse("Phlm VER. 6").osis()).toEqual("Phlm.1.6");
-      expect(p.parse("Exod 1:1 Ver 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      expect(p.parse("Phlm VER 6").osis()).toEqual("Phlm.1.6");
-      expect(p.parse("Exod 1:1 Vs. 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      expect(p.parse("Phlm VS. 6").osis()).toEqual("Phlm.1.6");
-      expect(p.parse("Exod 1:1 Vs 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      return expect(p.parse("Phlm VS 6").osis()).toEqual("Phlm.1.6");
+      expect(p.parse("Exod 1:1 Versen 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Versen 3'");
+      expect(p.parse("Phlm VERSEN 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERSEN 6'");
+      expect(p.parse("Exod 1:1 Verses 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Verses 3'");
+      expect(p.parse("Phlm VERSES 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERSES 6'");
+      expect(p.parse("Exod 1:1 Verse 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Verse 3'");
+      expect(p.parse("Phlm VERSE 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERSE 6'");
+      expect(p.parse("Exod 1:1 Vers. 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vers. 3'");
+      expect(p.parse("Phlm VERS. 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERS. 6'");
+      expect(p.parse("Exod 1:1 Vers 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vers 3'");
+      expect(p.parse("Phlm VERS 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERS 6'");
+      expect(p.parse("Exod 1:1 Vers 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vers 3'");
+      expect(p.parse("Phlm VERS 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VERS 6'");
+      expect(p.parse("Exod 1:1 Vs. 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vs. 3'");
+      expect(p.parse("Phlm VS. 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VS. 6'");
+      expect(p.parse("Exod 1:1 Vs 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 Vs 3'");
+      return expect(p.parse("Phlm VS 6").osis()).toEqual("Phlm.1.6", "parsing: 'Phlm VS 6'");
     });
     it("should handle 'and' (de)", function() {
-      expect(p.parse("Exod 1:1 und 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      expect(p.parse("Phlm 2 UND 6").osis()).toEqual("Phlm.1.2,Phlm.1.6");
-      expect(p.parse("Exod 1:1 vgl. 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      expect(p.parse("Phlm 2 VGL. 6").osis()).toEqual("Phlm.1.2,Phlm.1.6");
-      expect(p.parse("Exod 1:1 vgl 3").osis()).toEqual("Exod.1.1,Exod.1.3");
-      return expect(p.parse("Phlm 2 VGL 6").osis()).toEqual("Phlm.1.2,Phlm.1.6");
+      expect(p.parse("Exod 1:1 und siehe auch 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 und siehe auch 3'");
+      expect(p.parse("Phlm 2 UND SIEHE AUCH 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 UND SIEHE AUCH 6'");
+      expect(p.parse("Exod 1:1 und siehe 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 und siehe 3'");
+      expect(p.parse("Phlm 2 UND SIEHE 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 UND SIEHE 6'");
+      expect(p.parse("Exod 1:1 und auch 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 und auch 3'");
+      expect(p.parse("Phlm 2 UND AUCH 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 UND AUCH 6'");
+      expect(p.parse("Exod 1:1 sowie auch 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 sowie auch 3'");
+      expect(p.parse("Phlm 2 SOWIE AUCH 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 SOWIE AUCH 6'");
+      expect(p.parse("Exod 1:1 siehe auch 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 siehe auch 3'");
+      expect(p.parse("Phlm 2 SIEHE AUCH 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 SIEHE AUCH 6'");
+      expect(p.parse("Exod 1:1 siehe 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 siehe 3'");
+      expect(p.parse("Phlm 2 SIEHE 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 SIEHE 6'");
+      expect(p.parse("Exod 1:1 sowie 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 sowie 3'");
+      expect(p.parse("Phlm 2 SOWIE 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 SOWIE 6'");
+      expect(p.parse("Exod 1:1 u. 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 u. 3'");
+      expect(p.parse("Phlm 2 U. 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 U. 6'");
+      expect(p.parse("Exod 1:1 u 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 u 3'");
+      expect(p.parse("Phlm 2 U 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 U 6'");
+      expect(p.parse("Exod 1:1 & 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 & 3'");
+      expect(p.parse("Phlm 2 & 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 & 6'");
+      expect(p.parse("Exod 1:1 vgl. 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 vgl. 3'");
+      expect(p.parse("Phlm 2 VGL. 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 VGL. 6'");
+      expect(p.parse("Exod 1:1 vgl 3").osis()).toEqual("Exod.1.1,Exod.1.3", "parsing: 'Exod 1:1 vgl 3'");
+      return expect(p.parse("Phlm 2 VGL 6").osis()).toEqual("Phlm.1.2,Phlm.1.6", "parsing: 'Phlm 2 VGL 6'");
     });
     it("should handle titles (de)", function() {
-      expect(p.parse("Ps 3 Titel, 4:2, 5:Titel").osis()).toEqual("Ps.3.1,Ps.4.2,Ps.5.1");
-      return expect(p.parse("PS 3 TITEL, 4:2, 5:TITEL").osis()).toEqual("Ps.3.1,Ps.4.2,Ps.5.1");
+      expect(p.parse("Ps 3 Titel, 4:2, 5:Titel").osis()).toEqual("Ps.3.1,Ps.4.2,Ps.5.1", "parsing: 'Ps 3 Titel, 4:2, 5:Titel'");
+      return expect(p.parse("PS 3 TITEL, 4:2, 5:TITEL").osis()).toEqual("Ps.3.1,Ps.4.2,Ps.5.1", "parsing: 'PS 3 TITEL, 4:2, 5:TITEL'");
     });
     it("should handle 'ff' (de)", function() {
-      expect(p.parse("Rev 3ff, 4:2ff").osis()).toEqual("Rev.3-Rev.22,Rev.4.2-Rev.4.11");
-      return expect(p.parse("REV 3 FF, 4:2 FF").osis()).toEqual("Rev.3-Rev.22,Rev.4.2-Rev.4.11");
+      expect(p.parse("Rev 3ff, 4:2ff").osis()).toEqual("Rev.3-Rev.22,Rev.4.2-Rev.4.11", "parsing: 'Rev 3ff, 4:2ff'");
+      return expect(p.parse("REV 3 FF, 4:2 FF").osis()).toEqual("Rev.3-Rev.22,Rev.4.2-Rev.4.11", "parsing: 'REV 3 FF, 4:2 FF'");
     });
     it("should handle translations (de)", function() {
       expect(p.parse("Lev 1 (ELB)").osis_and_translations()).toEqual([["Lev.1", "ELB"]]);
@@ -2715,14 +3088,14 @@
         book_alone_strategy: "full",
         book_range_strategy: "include"
       });
-      return expect(p.parse("Erste bis Dritte  Johannes").osis()).toEqual("1John.1-3John.1");
+      return expect(p.parse("Ersten bis Dritten  Johannes").osis()).toEqual("1John.1-3John.1", "parsing: 'Ersten bis Dritten  Johannes'");
     });
     return it("should handle boundaries (de)", function() {
       p.set_options({
         book_alone_strategy: "full"
       });
-      expect(p.parse("\u2014Matt\u2014").osis()).toEqual("Matt.1-Matt.28");
-      return expect(p.parse("\u201cMatt 1:1\u201d").osis()).toEqual("Matt.1.1");
+      expect(p.parse("\u2014Matt\u2014").osis()).toEqual("Matt.1-Matt.28", "parsing: '\u2014Matt\u2014'");
+      return expect(p.parse("\u201cMatt 1:1\u201d").osis()).toEqual("Matt.1.1", "parsing: '\u201cMatt 1:1\u201d'");
     });
   });
 


### PR DESCRIPTION
In an initial commit, I've added all NodeJS dependencies to the package.json. This simplifies the process significantly, as all dependencies are explicit (except for perl and its JSON module) and installed with a single command.
In the same commit I've added npm scripts for the 2 build steps and for running tests. They are somewhat cleaner and more accessible than the perl scripts and the previously documented test script did not exist!

In the second commit I added a Jasmine matcher string to most expectations, which is printed out when an expectation fails. This was necessary to debug pegjs expressions that were initially failing in the next step.

The two subsequent commits make several improvements to the German data.txt and add all generated _de_ files for these changes. I have not build the _full_ or _ascii_ version yet. 